### PR TITLE
Portability fix for Strophe.Builder.prototype.cnode()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -987,8 +987,9 @@ Strophe.Builder.prototype = {
      */
     cnode: function (elem)
     {
-        this.node.appendChild(elem);
-        this.node = elem;
+        var newElem = Strophe.copyElement(elem);
+        this.node.appendChild(newElem);
+        this.node = newElem;
         return this;
     },
 


### PR DESCRIPTION
Strophe is currently unable to run under Google Chrome, SRWare Iron and similar browsers. This patch fixes that. Details are explained in the commit message.

The commit message also proposes an alternative way (via "importNode()") to fix the issue. If you prefer that, please drop me a note. I'll then create and test an alternative patch for you.

Greets,
Volker
