### PR TITLE
Double Disconnect

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2404,7 +2404,7 @@ Strophe.Connection.prototype = {
 
         var typ = elem.getAttribute("type");
         var cond, conflict;
-        if (typ !== null && typ == "terminate") {
+        if (typ !== null && typ == "terminate" && !this.disconnecting) {
             // an error occurred
             cond = elem.getAttribute("condition");
             conflict = elem.getElementsByTagName("conflict");

--- a/src/core.js
+++ b/src/core.js
@@ -2404,7 +2404,10 @@ Strophe.Connection.prototype = {
 
         var typ = elem.getAttribute("type");
         var cond, conflict;
-        if (typ !== null && typ == "terminate" && !this.disconnecting) {
+        if (typ !== null && typ == "terminate") {
+            if (this.disconnecting) {
+                return;
+            }
             // an error occurred
             cond = elem.getAttribute("condition");
             conflict = elem.getElementsByTagName("conflict");


### PR DESCRIPTION
Ok, so I found the issue causing this bug: http://github.com/metajack/strophejs/issues#issue/2

If more than one connection is allowed, the terminate/unavailable stanza is sent on a new connection, which gets a terminate response. There is still another open connection, however, so instead of the final part of closing a connection being performed:

```
    // handle graceful disconnect
    if (this.disconnecting && this._requests.length === 0) {
        this.deleteTimedHandler(this._disconnectTimeout);
        this._disconnectTimeout = null;
        this._doDisconnect();
        return;
    }
```

We actually consider the terminate response to be a connection error. In order to handle this correctly, we need to cease considering this as an error, by testing if a disconnect is in progress.
