### PR TITLE
Basic support for sending html messages in MUC.

### DIFF
--- a/plugins/strophe.muc.js
+++ b/plugins/strophe.muc.js
@@ -144,11 +144,11 @@ Strophe.addConnectionPlugin('muc', {
         if(typeof html_message !== 'undefined')
         {
             msg.c("html", {xmlns: Strophe.NS.XHTML_IM}).c("body", {xmlns: Strophe.NS.XHTML}).h(html_message);
-
             if(msg.node.childNodes.length == 0) // html creation or import failed somewhere; fallback to plaintext
             {
+                parent = msg.node.parentNode;
                 msg.up().up();
-                this.node.removeChild(this.node.childNodes[1]); // get rid of the empty html element if we got invalid html so we don't send an empty message
+                msg.node.removeChild(parent); // get rid of the empty html element if we got invalid html so we don't send an empty message
             }
             else
             {

--- a/plugins/strophe.muc.js
+++ b/plugins/strophe.muc.js
@@ -127,11 +127,12 @@ Strophe.addConnectionPlugin('muc', {
     Parameters:
     (String) room - The multi-user chat room name.
     (String) nick - The nick name used in the chat room.
-    (String) message - The message to send to the room.
+    (String) message - The plaintext message to send to the room.
+    (String) html_message - The message to send to the room with html markup.
     Returns:
     msgiq - the unique id used to send the message
     */
-    message: function(room, nick, message) {
+    message: function(room, nick, message, html_message) {
         var room_nick = this.test_append_nick(room, nick);        
         var msgid = this._connection.getUniqueId();
         var msg = $msg({to: room_nick,
@@ -139,7 +140,13 @@ Strophe.addConnectionPlugin('muc', {
                         type: "groupchat",
                         id: msgid}).c("body",
                                       {xmlns: Strophe.NS.CLIENT}).t(message);
-        msg.up().c("x", {xmlns: "jabber:x:event"}).c("composing");
+        msg.up();
+        if(typeof html_message !== 'undefined')
+        {
+            msg.c("html", {xmlns: Strophe.NS.XHTML_IM}).c("body", {xmlns: Strophe.NS.XHTML}).h(html_message);
+            msg.up().up();
+        }
+        msg.c("x", {xmlns: "jabber:x:event"}).c("composing");
         this._connection.send(msg);
         return msgid;
     },

--- a/plugins/strophe.muc.js
+++ b/plugins/strophe.muc.js
@@ -144,7 +144,16 @@ Strophe.addConnectionPlugin('muc', {
         if(typeof html_message !== 'undefined')
         {
             msg.c("html", {xmlns: Strophe.NS.XHTML_IM}).c("body", {xmlns: Strophe.NS.XHTML}).h(html_message);
-            msg.up().up();
+
+            if(msg.node.childNodes.length == 0) // html creation or import failed somewhere; fallback to plaintext
+            {
+                msg.up().up();
+                this.node.removeChild(this.node.childNodes[1]); // get rid of the empty html element if we got invalid html so we don't send an empty message
+            }
+            else
+            {
+                msg.up().up();
+            }
         }
         msg.c("x", {xmlns: "jabber:x:event"}).c("composing");
         this._connection.send(msg);

--- a/src/core.js
+++ b/src/core.js
@@ -646,6 +646,9 @@ Strophe = {
     createHtml: function (elem)
     {
         var i, el, j, tag, attribute, value, css, cssAttrs, attr, cssName, cssValue, children, child;
+        if (!Strophe._xmlGenerator) {
+            Strophe._xmlGenerator = Strophe._makeGenerator();
+        }
         if (elem.nodeType == Strophe.ElementType.NORMAL) {
             tag = elem.nodeName.toLowerCase();
             if(Strophe.XHTML.validTag(tag))
@@ -701,14 +704,13 @@ Strophe = {
             }
             else
             {
-                children = document.createDocumentFragment();
+                el = Strophe._xmlGenerator.createDocumentFragment();
                 for (i = 0; i < elem.childNodes.length; i++) {
-                    children.appendChild(Strophe.createHtml(elem.childNodes[i]));
+                    el.appendChild(Strophe.createHtml(elem.childNodes[i]));
                 }
-                return children;
             }
         } else if (elem.nodeType == Strophe.ElementType.FRAGMENT) {
-            el = document.createDocumentFragment();
+            el = Strophe._xmlGenerator.createDocumentFragment();
             for (i = 0; i < elem.childNodes.length; i++) {
                 el.appendChild(Strophe.createHtml(elem.childNodes[i]));
             }

--- a/src/core.js
+++ b/src/core.js
@@ -698,7 +698,7 @@ Strophe = {
                     {
                         attribute = Strophe.XHTML.attributes[tag][i];
                         value = elem.getAttribute(attribute);
-                        if(value === null || value === '' || value === false || value === 0)
+                        if(typeof value == 'undefined' || value === null || value === '' || value === false || value === 0)
                         {
                             continue;
                         }
@@ -709,33 +709,30 @@ Strophe = {
                                 value = value.cssText; // we're dealing with IE, need to get CSS out
                             }
                         }
-                        if(!value.match(/0|null|undefined|false/))
+                        // filter out invalid css styles
+                        if(attribute == 'style')
                         {
-                            // filter out invalid css styles
-                            if(attribute == 'style')
+                            css = [];
+                            cssAttrs = value.split(';');
+                            for(j = 0; j < cssAttrs.length; j++)
                             {
-                                css = [];
-                                cssAttrs = value.split(';');
-                                for(j = 0; j < cssAttrs.length; j++)
+                                attr = cssAttrs[j].split(':');
+                                cssName = attr[0].replace(/^\s*/, "").replace(/\s*$/, "").toLowerCase();
+                                if(Strophe.XHTML.validCSS(cssName))
                                 {
-                                    attr = cssAttrs[j].split(':');
-                                    cssName = attr[0].replace(/^\s*/, "").replace(/\s*$/, "").toLowerCase();
-                                    if(Strophe.XHTML.validCSS(cssName))
-                                    {
-                                        cssValue = attr[1].replace(/^\s*/, "").replace(/\s*$/, "");
-                                        css.push(cssName + ': ' + cssValue);
-                                    }
-                                }
-                                if(css.length > 0)
-                                {
-                                    value = css.join('; ');
-                                    el.setAttribute(attribute, value);
+                                    cssValue = attr[1].replace(/^\s*/, "").replace(/\s*$/, "");
+                                    css.push(cssName + ': ' + cssValue);
                                 }
                             }
-                            else
+                            if(css.length > 0)
                             {
+                                value = css.join('; ');
                                 el.setAttribute(attribute, value);
                             }
+                        }
+                        else
+                        {
+                            el.setAttribute(attribute, value);
                         }
                     }
 

--- a/src/core.js
+++ b/src/core.js
@@ -1054,12 +1054,23 @@ Strophe.Builder.prototype = {
      */
     h: function (html)
     {
-        /* add a wrapper in case html is a standalone fragment */
-        html = Strophe.xmlHtmlNode('<body>' + html + '</body>');
+        var node = null;
+        /* add a wrapper in case html is an unenclosed fragment */
+        var html = Strophe.xmlHtmlNode('<body>' + html + '</body>');
         html = html.childNodes[0];
         while(html.childNodes.length > 0)
         {
-            this.node.appendChild(html.childNodes[0]);
+            if (document.importNode)
+            {
+                node = document.importNode(html.childNodes[0], true);
+                html.removeChild(html.childNodes[0]);
+                this.node.appendChild(node);
+                node = null;
+            }
+            else // IE doesn't have importNode
+            {
+                this.node.appendChild(html.childNodes[0]);
+            }
         }
         return this;
     }

--- a/src/core.js
+++ b/src/core.js
@@ -566,6 +566,48 @@ Strophe = {
         return el;
     },
 
+
+    /** Function: copyHtml
+     *  Copy an HTML DOM element into an XML DOM.
+     *
+     *  This function copies a DOM element and all its descendants and returns
+     *  the new copy.
+     *
+     *  Parameters:
+     *    (HTMLElement) elem - A DOM element.
+     *
+     *  Returns:
+     *    A new, copied DOM element tree.
+     */
+    copyHtml: function (elem)
+    {
+        var i, el;
+        if (elem.nodeType == Strophe.ElementType.NORMAL) {
+            try
+            {
+                el = Strophe.xmlElement(elem.tagName);
+                for (i = 0; i < elem.attributes.length; i++) {
+                    if(elem.attributes[i].nodeName.toLowerCase().match(/href|src|target/) && !elem.attributes[i].value.match(/0|null|undefined|false/) && elem.attributes[i].value !== '')
+                    {
+                        el.setAttribute(elem.attributes[i].nodeName.toLowerCase(),
+                                elem.attributes[i].value);
+                    }
+                }
+
+                for (i = 0; i < elem.childNodes.length; i++) {
+                    el.appendChild(Strophe.copyHtml(elem.childNodes[i]));
+                }
+            }
+            catch(e) { // invalid elements
+              el = Strophe.xmlTextNode('');
+            }
+        } else if (elem.nodeType == Strophe.ElementType.TEXT) {
+            el = Strophe.xmlTextNode(elem.nodeValue);
+        }
+
+        return el;
+    },
+
     /** Function: escapeNode
      *  Escape the node part (also called local part) of a JID.
      *
@@ -1054,12 +1096,18 @@ Strophe.Builder.prototype = {
      */
     h: function (html)
     {
-        var node = null;
-        var fragment = document.createElement('div');
-        fragment.innerHTML = html;
-        while(fragment.childNodes.length > 0)
+        var fragment = document.createDocumentFragment();
+        fragment.appendChild(document.createElement('div'));
+
+        // force the browser to try and fix any invalid HTML tags
+        fragment.childNodes[0].innerHTML = html;
+
+        // copy cleaned html into an xml dom
+        var xhtml = Strophe.copyHtml(fragment.childNodes[0]);
+
+        while(xhtml.childNodes.length > 0)
         {
-            this.node.appendChild(fragment.childNodes[0]);
+            this.node.appendChild(xhtml.childNodes[0]);
         }
         return this;
     }

--- a/src/core.js
+++ b/src/core.js
@@ -1055,22 +1055,11 @@ Strophe.Builder.prototype = {
     h: function (html)
     {
         var node = null;
-        /* add a wrapper in case html is an unenclosed fragment */
-        var html = Strophe.xmlHtmlNode('<body>' + html + '</body>');
-        html = html.childNodes[0];
-        while(html.childNodes.length > 0)
+        var fragment = document.createElement('div');
+        fragment.innerHTML = html;
+        while(fragment.childNodes.length > 0)
         {
-            if (document.importNode)
-            {
-                node = document.importNode(html.childNodes[0], true);
-                html.removeChild(html.childNodes[0]);
-                this.node.appendChild(node);
-                node = null;
-            }
-            else // IE doesn't have importNode
-            {
-                this.node.appendChild(html.childNodes[0]);
-            }
+            this.node.appendChild(fragment.childNodes[0]);
         }
         return this;
     }

--- a/src/core.js
+++ b/src/core.js
@@ -203,6 +203,8 @@ Strophe = {
      *  NS.STREAM - XMPP Streams namespace from RFC 3920.
      *  NS.BIND - XMPP Binding namespace from RFC 3920.
      *  NS.SESSION - XMPP Session namespace from RFC 3920.
+     *  NS.XHTML_IM - XHTML-IM namespace from XEP 71.
+     *  NS.XHTML - XHTML body namespace from XEP 71.
      */
     NS: {
         HTTPBIND: "http://jabber.org/protocol/httpbind",
@@ -219,7 +221,9 @@ Strophe = {
         BIND: "urn:ietf:params:xml:ns:xmpp-bind",
         SESSION: "urn:ietf:params:xml:ns:xmpp-session",
         VERSION: "jabber:iq:version",
-        STANZAS: "urn:ietf:params:xml:ns:xmpp-stanzas"
+        STANZAS: "urn:ietf:params:xml:ns:xmpp-stanzas",
+        XHTML_IM: "http://jabber.org/protocol/xhtml-im",
+        XHTML: "http://www.w3.org/1999/xhtml"
     },
 
     /** Function: addNamespace 
@@ -473,6 +477,32 @@ Strophe = {
             Strophe._xmlGenerator = Strophe._makeGenerator();
         }
         return Strophe._xmlGenerator.createTextNode(text);
+    },
+
+    /** Function: xmlHtmlNode
+     *  Creates an XML DOM html node.
+     *
+     *  Parameters:
+     *    (String) html - The content of the html node.
+     *
+     *  Returns:
+     *    A new XML DOM text node.
+     */
+    xmlHtmlNode: function (html)
+    {
+        //ensure text is escaped
+        if (window.DOMParser)
+        {
+            parser = new DOMParser();
+            node = parser.parseFromString(html, "text/xml");
+        }
+        else
+        {
+            node = new ActiveXObject("Microsoft.XMLDOM");
+            node.async="false";
+            node.loadXML(html);
+        }
+        return node;
     },
 
     /** Function: getText
@@ -1008,6 +1038,23 @@ Strophe.Builder.prototype = {
     {
         var child = Strophe.xmlTextNode(text);
         this.node.appendChild(child);
+        return this;
+    },
+
+    /** Function: h
+     *  Replace current element contents with the HTML passed in.
+     *
+     *  This *does not* make the child the new current element
+     *
+     *  Parameters:
+     *    (String) html - The html to insert as contents of current element.
+     *
+     *  Returns:
+     *    The Strophe.Builder object.
+     */
+    h: function (html)
+    {
+        this.node.textContent = html;
         return this;
     }
 };

--- a/src/core.js
+++ b/src/core.js
@@ -660,11 +660,18 @@ Strophe = {
                     {
                         attribute = Strophe.XHTML.attributes[tag][i];
                         value = elem.getAttribute(attribute);
+                        if(value === null || value === '' || value === false || value === 0)
+                        {
+                            continue;
+                        }
                         if(attribute == 'style' && typeof value == 'object')
                         {
-                            value = value.cssText; // we're dealing with IE, need to get CSS out
+                            if(typeof value.cssText != 'undefined')
+                            {
+                                value = value.cssText; // we're dealing with IE, need to get CSS out
+                            }
                         }
-                        if(!value.match(/0|null|undefined|false/) && value !== '')
+                        if(!value.match(/0|null|undefined|false/))
                         {
                             // filter out invalid css styles
                             if(attribute == 'style')

--- a/src/core.js
+++ b/src/core.js
@@ -687,9 +687,6 @@ Strophe = {
     createHtml: function (elem)
     {
         var i, el, j, tag, attribute, value, css, cssAttrs, attr, cssName, cssValue, children, child;
-        if (!Strophe._xmlGenerator) {
-            Strophe._xmlGenerator = Strophe._makeGenerator();
-        }
         if (elem.nodeType == Strophe.ElementType.NORMAL) {
             tag = elem.nodeName.toLowerCase();
             if(Strophe.XHTML.validTag(tag))
@@ -752,13 +749,13 @@ Strophe = {
             }
             else
             {
-                el = Strophe._xmlGenerator.createDocumentFragment();
+                el = Strophe.xmlGenerator().createDocumentFragment();
                 for (i = 0; i < elem.childNodes.length; i++) {
                     el.appendChild(Strophe.createHtml(elem.childNodes[i]));
                 }
             }
         } else if (elem.nodeType == Strophe.ElementType.FRAGMENT) {
-            el = Strophe._xmlGenerator.createDocumentFragment();
+            el = Strophe.xmlGenerator().createDocumentFragment();
             for (i = 0; i < elem.childNodes.length; i++) {
                 el.appendChild(Strophe.createHtml(elem.childNodes[i]));
             }

--- a/src/core.js
+++ b/src/core.js
@@ -653,10 +653,15 @@ Strophe = {
                 try
                 {
                     el = Strophe.xmlElement(tag);
-                    for (i = 0; i < elem.attributes.length; i++) {
-                        attribute = elem.attributes[i].nodeName.toLowerCase();
-                        value = elem.attributes[i].value;
-                        if(Strophe.XHTML.validAttribute(tag, attribute) && !value.match(/0|null|undefined|false/) && value !== '')
+                    for(i = 0; i < Strophe.XHTML.attributes[tag].length; i++)
+                    {
+                        attribute = Strophe.XHTML.attributes[tag][i];
+                        value = elem.getAttribute(attribute);
+                        if(attribute == 'style' && typeof value == 'object')
+                        {
+                            value = value.cssText; // we're dealing with IE, need to get CSS out
+                        }
+                        if(!value.match(/0|null|undefined|false/) && value !== '')
                         {
                             // filter out invalid css styles
                             if(attribute == 'style')
@@ -691,29 +696,21 @@ Strophe = {
                     }
                 }
                 catch(e) { // invalid elements
-                  el = false;
+                  el = Strophe.xmlTextNode('');
                 }
             }
             else
             {
                 children = document.createDocumentFragment();
                 for (i = 0; i < elem.childNodes.length; i++) {
-                    child = Strophe.createHtml(elem.childNodes[i]);
-                    if(child !== false)
-                    {
-                        children.appendChild(child);
-                    }
+                    children.appendChild(Strophe.createHtml(elem.childNodes[i]));
                 }
                 return children;
             }
         } else if (elem.nodeType == Strophe.ElementType.FRAGMENT) {
             el = document.createDocumentFragment();
             for (i = 0; i < elem.childNodes.length; i++) {
-                child = Strophe.createHtml(elem.childNodes[i]);
-                if(child !== false)
-                {
-                    el.appendChild(child);
-                }
+                el.appendChild(Strophe.createHtml(elem.childNodes[i]));
             }
         } else if (elem.nodeType == Strophe.ElementType.TEXT) {
             el = Strophe.xmlTextNode(elem.nodeValue);

--- a/src/core.js
+++ b/src/core.js
@@ -962,9 +962,10 @@ Strophe = {
                if(elem.attributes[i].nodeName != "_realname") {
                  result += " " + elem.attributes[i].nodeName.toLowerCase() +
                 "='" + elem.attributes[i].value
-                    .replace("&", "&amp;")
-                       .replace("'", "&apos;")
-                       .replace("<", "&lt;") + "'";
+                    .replace(/&/g, "&amp;")
+                       .replace(/'/g, "&apos;")
+                       .replace(/</g, "&lt;")
+                       .replace(/>/g, "&gt;") + "'";
                }
         }
 

--- a/src/core.js
+++ b/src/core.js
@@ -1054,11 +1054,16 @@ Strophe.Builder.prototype = {
      */
     h: function (html)
     {
-        this.node.textContent = html;
+        /* add a wrapper in case html is a standalone fragment */
+        html = Strophe.xmlHtmlNode('<body>' + html + '</body>');
+        html = html.childNodes[0];
+        while(html.childNodes.length > 0)
+        {
+            this.node.appendChild(html.childNodes[0]);
+        }
         return this;
     }
 };
-
 
 /** PrivateClass: Strophe.Handler
  *  _Private_ helper class for managing stanza handlers.


### PR DESCRIPTION
I've been working on our MUC system at work; this is the changes I had to add to the strophe core. Any client code using html messaging needs to do xss filtering and protection against injected messages; that's out of scope of the core code though. Thanks for the great library.

I still get spurious 404 and 503 responses from the /xmpp-httpbind proxy url occasionally; haven't had a chance to look into making it more resistant to those; right now it just disconnects if I get those.
