### PR TITLE
Fix bugs related to back-off interval when handling errors

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2159,7 +2159,6 @@ Strophe.Connection.prototype = {
             Strophe.debug("request id " + req.id +
                           "." + req.sends + " posting");
 
-            req.date = new Date();
             try {
                 req.xhr.open("POST", this.service, true);
             } catch (e2) {
@@ -2175,6 +2174,7 @@ Strophe.Connection.prototype = {
             // Fires the XHR request -- may be invoked immediately
             // or on a gradually expanding retry window for reconnects
             var sendFunc = function () {
+                req.date = new Date();
                 req.xhr.send(req.data);
             };
 

--- a/src/core.js
+++ b/src/core.js
@@ -2181,9 +2181,10 @@ Strophe.Connection.prototype = {
             // Implement progressive backoff for reconnects --
             // First retry (send == 1) should also be instantaneous
             if (req.sends > 1) {
-                // Using a cube of the retry number creats a nicely
+                // Using a cube of the retry number creates a nicely
                 // expanding retry window
-                var backoff = Math.pow(req.sends, 3) * 1000;
+                var backoff = Math.min(Math.floor(Strophe.TIMEOUT * this.wait),
+                                       Math.pow(req.sends, 3)) * 1000;
                 setTimeout(sendFunc, backoff);
             } else {
                 sendFunc();


### PR DESCRIPTION
If the 'wait' parameter is set to anything <= 58 seconds and more than 3 connection errors occur, strophe gets stuck and will never make another connection to the server.

This happens because the back-off interval is counted towards the request timeout.  So, for example, if the 'wait' parameter is set to 50 seconds, then the request will time out after 55 seconds.  However, if there have been 3 errors, then the 4th retry attempt will not actually send the request until 4^3 =64 seconds after the request has been created, but the request will be timed out and retried 55 seconds after it was created, which means that the request is not actually sent before it is timed out and retried.  At this point, strophe ends up in an infinite loop trying to retry a request that will always be timed out before it is actually sent.

I've written two minor patches to correct this behavior.  One patch sets req.date when the request is sent rather than when it is created, so that the request timeout is independent from the back-off interval (I assume this was the originally intended behavior).  The other patch caps the back-off interval at the request timeout value, to ensure that at least one request attempt is made within each request timeout interval (the server I am connecting to has a relatively short BOSH session timeout, so I adjusted my request timeout accordingly to ensure that multiple errors can occur and be retried before the session timeout expires ... but this does no good unless the back-off interval is also adjusted accordingly).

Thanks!
