### PR TITLE
Checking for 'xmlGen.importNode' breaks IE9

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -341,7 +341,7 @@ Strophe = {
     _makeGenerator: function () {
         var doc;
 
-        if (window.ActiveXObject) {
+        if (document.implementation.createDocument === undefined) {
             doc = this._getIEXmlDom();
             doc.appendChild(doc.createElement('strophe'));
         } else {


### PR DESCRIPTION
In line 1005 checking 'xmlGen.importNode' breaks IE9 with the error: "Wrong number of arguments or invalid property assignment" this is silly for the browser to do, but nonetheless, there's a simple workaround that solves this problem.

Since IE9 implements `document.implementation.createDocument` (which is what strophe already uses for modern browsers) we can just check whether that is defined rather than `window.ActiveXObject` since IE9 has both. Strophe may as well use `createDocument` if it's available.
