### PR TITLE
Untitled

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -544,7 +544,7 @@ Strophe = {
                 el.appendChild(Strophe.copyElement(elem.childNodes[i]));
             }
         } else if (elem.nodeType == Strophe.ElementType.TEXT) {
-            el = Strophe.xmlTextNode(elem.nodeValue);
+            el = Strophe.xmlGenerator().createTextNode(elem.nodeValue);
         }
 
         return el;

--- a/src/core.js
+++ b/src/core.js
@@ -1002,7 +1002,8 @@ Strophe.Builder.prototype = {
     cnode: function (elem)
     {
         var xmlGen = Strophe.xmlGenerator();
-        var newElem = xmlGen.importNode ? xmlGen.importNode(elem, true) : Strophe.copyElement(elem);
+        var newElem = typeof xmlGen.importNode !== 'unknown' && xmlGen.importNode ? xmlGen.importNode(elem, true) : Strophe.copyElement(elem);
+
         this.node.appendChild(newElem);
         this.node = newElem;
         return this;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -123,6 +123,12 @@ $(document).ready(function () {
         equals(elem.tagName, "message", "Element name should be the same");
     });
 
+    test("copyElement() double escape bug", function() {
+        var cloned = Strophe.copyElement(Strophe.xmlGenerator()
+            .createTextNode('<>&lt;&gt;'));
+        equals(cloned.nodeValue, '<>&lt;&gt;');
+    });
+
     test("detect importNode properly", function() {
       var elem = Strophe.xmlElement("test"),
       builder = new Strophe.Builder("test");

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -123,6 +123,18 @@ $(document).ready(function () {
         equals(elem.tagName, "message", "Element name should be the same");
     });
 
+    test("detect importNode properly", function() {
+      var elem = Strophe.xmlElement("test"),
+      builder = new Strophe.Builder("test");
+      try {
+        builder.cnode(elem);
+      } catch(e) {
+        ok(false, "should not throw exception");
+        return;
+      }
+      ok(true, "should run without exception");
+    });
+
     module("Handler");
 
     test("Full JID matching", function () {


### PR DESCRIPTION
fixes the following issues:

copyElement will double escape XML
https://github.com/metajack/strophejs/issues#issue/28

"TypeError: Wrong number of arguments or invalid property assignment"
mentioned here:
https://github.com/metajack/strophejs/issues#issue/15
and here:
https://github.com/metajack/strophejs/issues#issue/35
