### PR TITLE
Fixes for Strophe.xmlescape and Strophe.serialize

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -263,7 +263,8 @@ Strophe = {
      */
     ElementType: {
         NORMAL: 1,
-        TEXT: 3
+        TEXT: 3,
+        CDATA: 4
     },
 
     /** PrivateConstants: Timeout Values
@@ -796,12 +797,18 @@ Strophe = {
             result += ">";
             for (i = 0; i < elem.childNodes.length; i++) {
                 child = elem.childNodes[i];
-                if (child.nodeType == Strophe.ElementType.NORMAL) {
+                switch( child.nodeType ){
+                  case Strophe.ElementType.NORMAL:
                     // normal element, so recurse
                     result += Strophe.serialize(child);
-                } else if (child.nodeType == Strophe.ElementType.TEXT) {
-                    // text element
-                    result += child.nodeValue;
+                    break;
+                  case Strophe.ElementType.TEXT:
+                    // text element to escape values
+                    result += Strophe.xmlescape(child.nodeValue);
+                    break;
+                  case Strophe.ElementType.CDATA:
+                    // cdata section so don't escape values
+                    result += "<![CDATA["+child.nodeValue+"]]>";
                 }
             }
             result += "</" + nodeName + ">";

--- a/src/core.js
+++ b/src/core.js
@@ -464,9 +464,11 @@ Strophe = {
      */
     xmlescape: function(text)
     {
-	text = text.replace(/\&/g, "&amp;");
+        text = text.replace(/\&/g, "&amp;");
         text = text.replace(/</g,  "&lt;");
         text = text.replace(/>/g,  "&gt;");
+        text = text.replace(/'/g,  "&apos;");
+        text = text.replace(/"/g,  "&quot;");
         return text;
     },
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -111,11 +111,14 @@ $(document).ready(function () {
 
     test("XML escaping test", function () {
         var text = "s & p";
-	var textNode = Strophe.xmlTextNode(text);
-	equals(Strophe.getText(textNode), "s &amp; p", "should be escaped");
-	var text0 = "s < & > p";
-	var textNode0 = Strophe.xmlTextNode(text0);
-	equals(Strophe.getText(textNode0), "s &lt; &amp; &gt; p", "should be escaped");
+        var textNode = Strophe.xmlTextNode(text);
+        equals(Strophe.getText(textNode), "s &amp; p", "should be escaped");
+        var text0 = "s < & > p";
+        var textNode0 = Strophe.xmlTextNode(text0);
+        equals(Strophe.getText(textNode0), "s &lt; &amp; &gt; p", "should be escaped");
+        var text1 = "s's or \"p\"";
+        var textNode1 = Strophe.xmlTextNode(text1);
+        equals(Strophe.getText(textNode1), "s&apos;s or &quot;p&quot;", "should be escaped");
     });
 
     test("XML element creation", function () {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -119,11 +119,52 @@ $(document).ready(function () {
         var text1 = "s's or \"p\"";
         var textNode1 = Strophe.xmlTextNode(text1);
         equals(Strophe.getText(textNode1), "s&apos;s or &quot;p&quot;", "should be escaped");
+        var text2 = "<![CDATA[<foo>]]>";
+        var textNode2 = Strophe.xmlTextNode(text2);
+        equals(Strophe.getText(textNode2), "&lt;![CDATA[&lt;foo&gt;]]&gt;", "should be escaped");
+        var text3 = "<![CDATA[]]]]><![CDATA[>]]>";
+        var textNode3 = Strophe.xmlTextNode(text3);
+        equals(Strophe.getText(textNode3), "&lt;![CDATA[]]]]&gt;&lt;![CDATA[&gt;]]&gt;", "should be escaped");
+        var text4 = "&lt;foo&gt;<![CDATA[<foo>]]>";
+        var textNode4 = Strophe.xmlTextNode(text4);
+        equals(Strophe.getText(textNode4), "&amp;lt;foo&amp;gt;&lt;![CDATA[&lt;foo&gt;]]&gt;", "should be escaped");
     });
 
     test("XML element creation", function () {
         var elem = Strophe.xmlElement("message");
         equals(elem.tagName, "message", "Element name should be the same");
+    });
+    
+    test("XML serializing", function() {
+        var parser = new DOMParser();
+        // Attributes
+        var element1 = parser.parseFromString("<foo attr1='abc' attr2='edf'>bar</foo>","text/xml").documentElement;
+        equals(Strophe.serialize(element1), "<foo attr1='abc' attr2='edf'>bar</foo>", "should be serialized");
+        var element2 = parser.parseFromString("<foo attr1=\"abc\" attr2=\"edf\">bar</foo>","text/xml").documentElement;
+        equals(Strophe.serialize(element2), "<foo attr1='abc' attr2='edf'>bar</foo>", "should be serialized");
+        // Escaping values
+        var element3 = parser.parseFromString("<foo>a &gt; &apos;b&apos; &amp; &quot;b&quot; &lt; c</foo>","text/xml").documentElement;
+        equals(Strophe.serialize(element3), "<foo>a &gt; &apos;b&apos; &amp; &quot;b&quot; &lt; c</foo>", "should be serialized");
+        // Escaping attributes
+        var element4 = parser.parseFromString("<foo attr='&lt;a> &apos;b&apos;'>bar</foo>","text/xml").documentElement;
+        equals(Strophe.serialize(element4), "<foo attr='&lt;a> &apos;b&apos;'>bar</foo>", "should be serialized");
+        var element5 = parser.parseFromString("<foo attr=\"&lt;a> &quot;b&quot;\">bar</foo>","text/xml").documentElement;
+        equals(Strophe.serialize(element5), "<foo attr='&lt;a> \"b\"'>bar</foo>", "should be serialized");
+        // Empty elements
+        var element6 = parser.parseFromString("<foo><empty></empty></foo>","text/xml").documentElement;
+        equals(Strophe.serialize(element6), "<foo><empty/></foo>", "should be serialized");
+        // Children
+        var element7 = parser.parseFromString("<foo><bar>a</bar><baz><wibble>b</wibble></baz></foo>","text/xml").documentElement;
+        equals(Strophe.serialize(element7), "<foo><bar>a</bar><baz><wibble>b</wibble></baz></foo>", "should be serialized");
+        var element8 = parser.parseFromString("<foo><bar>a</bar><baz>b<wibble>c</wibble>d</baz></foo>","text/xml").documentElement;
+        equals(Strophe.serialize(element8), "<foo><bar>a</bar><baz>b<wibble>c</wibble>d</baz></foo>", "should be serialized");
+        // CDATA
+        var element9 = parser.parseFromString("<foo><![CDATA[<foo>]]></foo>","text/xml").documentElement;
+        equals(Strophe.serialize(element9), "<foo><![CDATA[<foo>]]></foo>", "should be serialized");
+        var element10 = parser.parseFromString("<foo><![CDATA[]]]]><![CDATA[>]]></foo>","text/xml").documentElement;
+        equals(Strophe.serialize(element10), "<foo><![CDATA[]]]]><![CDATA[>]]></foo>", "should be serialized");
+        var element11 = parser.parseFromString("<foo>&lt;foo&gt;<![CDATA[<foo>]]></foo>","text/xml").documentElement;
+        equals(Strophe.serialize(element11), "<foo>&lt;foo&gt;<![CDATA[<foo>]]></foo>", "should be serialized");
     });
 
     module("Handler");


### PR DESCRIPTION
As per https://github.com/metajack/strophejs/issues/19

Strophe.xmlescape did not escape " and ' correctly.

Strophe.serialize did not escape element values correctly so invalid XML could be generated.

I've implemented the fixes and added qunit tests to demonstrate existing functionality has not been lost, and the fix has worked.
