### PR TITLE
Separate authentication

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1594,16 +1594,8 @@ Strophe.Connection.prototype = {
      *    (Integer) hold - The optional HTTPBIND hold value.  This is the
      *      number of connections the server will hold at one time.  This
      *      should almost always be set to 1 (the default).
-     *    (Boolean) authentication - The optional trigger for authentication
-     *      process. When set to false a successful connection request will
-     *      skip the authention process. The authentication process can
-     *      triggered manually by the 'authenticate' method.
-     *    (Function) _connect_cb - low level (xmpp) connect callback function.
-     *      Useful for plugins with their own xmpp connect callback (when their)
-     *      want to do something special).
      */
-    connect: function (jid, pass, callback, wait, hold,
-                       authentication, _connect_cb)
+    connect: function (jid, pass, callback, wait, hold)
     {
         this.jid = jid;
         this.pass = pass;
@@ -1615,7 +1607,6 @@ Strophe.Connection.prototype = {
 
         this.wait = wait || this.wait;
         this.hold = hold || this.hold;
-        this.do_authentication = authentication;
 
         // parse jid for domain and resource
         this.domain = this.domain || Strophe.getDomainFromJid(this.jid);
@@ -1634,7 +1625,9 @@ Strophe.Connection.prototype = {
 
         this._changeConnectStatus(Strophe.Status.CONNECTING, null);
 
-        _connect_cb = _connect_cb || this._connect_cb;
+        var _connect_cb = this._connect_callback || this._connect_cb;
+        this._connect_callback = null;
+
         this._requests.push(
             new Strophe.Request(body.tree(),
                                 this._onRequestStateChange.bind(

--- a/src/core.js
+++ b/src/core.js
@@ -1618,7 +1618,7 @@ Strophe.Connection.prototype = {
         this.do_authentication = authentication || this.do_authentication;
 
         // parse jid for domain and resource
-        this.domain = Strophe.getDomainFromJid(this.jid) || this.domain;
+        this.domain = this.domain || Strophe.getDomainFromJid(this.jid);
 
         // build the body tag
         var body = this._buildBody().attrs({

--- a/src/core.js
+++ b/src/core.js
@@ -1615,7 +1615,7 @@ Strophe.Connection.prototype = {
 
         this.wait = wait || this.wait;
         this.hold = hold || this.hold;
-        this.do_authentication = authentication || this.do_authentication;
+        this.do_authentication = authentication;
 
         // parse jid for domain and resource
         this.domain = this.domain || Strophe.getDomainFromJid(this.jid);
@@ -1638,7 +1638,7 @@ Strophe.Connection.prototype = {
         this._requests.push(
             new Strophe.Request(body.tree(),
                                 this._onRequestStateChange.bind(
-                                    this, this._connect_cb.bind(this)),
+                                    this, _connect_cb.bind(this)),
                                 body.tree().getAttribute("rid")));
         this._throttledRequestHandler();
     },
@@ -2640,12 +2640,13 @@ Strophe.Connection.prototype = {
             this._requests.push(
                 new Strophe.Request(body.tree(),
                                     this._onRequestStateChange.bind(
-                                        this, this._connect_cb.bind(this)),
+                                        this, _callback.bind(this)),
                                     body.tree().getAttribute("rid")));
             this._throttledRequestHandler();
             return;
         }
-        if (this.do_authentication) this.authenticate();
+        if (this.do_authentication !== false)
+            this.authenticate();
     },
 
     /** Function: authenticate

--- a/src/core.js
+++ b/src/core.js
@@ -1412,6 +1412,8 @@ Strophe.Connection = function (service)
     this.service = service;
     /* The connected JID. */
     this.jid = "";
+    /* the JIDs domain */
+    this.domain = null;
     /* request id for body tags */
     this.rid = Math.floor(Math.random() * 4294967295);
     /* The current session ID. */
@@ -1604,7 +1606,7 @@ Strophe.Connection.prototype = {
         this.hold = hold || this.hold;
 
         // parse jid for domain and resource
-        this.domain = Strophe.getDomainFromJid(this.jid);
+        this.domain = Strophe.getDomainFromJid(this.jid) || this.domain;
 
         // build the body tag
         var body = this._buildBody().attrs({


### PR DESCRIPTION
i separated the authentication process from the connection process so plugins like [register](https://github.com/dodo/strophejs-plugins/tree/register-with-updated-strophe/register) can operate after a bosh connection and before a user authentication.
