### PR TITLE
Fix for double-escaping in Strophe 1.0.2

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -486,9 +486,6 @@ Strophe = {
      */
     xmlTextNode: function (text)
     {
-	//ensure text is escaped
-	text = Strophe.xmlescape(text);
-
         return Strophe.xmlGenerator().createTextNode(text);
     },
 


### PR DESCRIPTION
This commit fixes a double-escaping bug introduced in 1.0.2. There's a simple test case in a HTML file at http://matthewwild.co.uk/uploads/test_escaping.html (sorry but I don't have time to figure out how to get Strophe's unit tests running at the moment).
