### PR TITLE
Handle resource conflicts

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2956,7 +2956,11 @@ Strophe.Connection.prototype = {
     {
         if (elem.getAttribute("type") == "error") {
             Strophe.info("SASL binding failed.");
-            this._changeConnectStatus(Strophe.Status.AUTHFAIL, null);
+			var conflict = elem.getElementsByTagName("conflict"), condition;
+			if (conflict.length > 0) {
+				condition = 'conflict';
+			}
+            this._changeConnectStatus(Strophe.Status.AUTHFAIL, condition);
             return false;
         }
 


### PR DESCRIPTION
Check for resource conflict during binding process and pass conflict as argument to the AUTHFAIL event.

This caters for servers implementing case #3 in the XMPP spec in the following section: http://xmpp.org/internet-drafts/draft-saintandre-rfc3920bis-08.html#bind-clientsubmit-error-conflict

This has recently been added to ejabberd, not sure about other server support.
