### PR TITLE
XHTML message support

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -663,6 +663,9 @@ Strophe = {
     createHtml: function (elem)
     {
         var i, el, j, tag, attribute, value, css, cssAttrs, attr, cssName, cssValue, children, child;
+        if (!Strophe._xmlGenerator) {
+            Strophe._xmlGenerator = Strophe._makeGenerator();
+        }
         if (elem.nodeType == Strophe.ElementType.NORMAL) {
             tag = elem.nodeName.toLowerCase();
             if(Strophe.XHTML.validTag(tag))
@@ -718,14 +721,13 @@ Strophe = {
             }
             else
             {
-                children = document.createDocumentFragment();
+                el = Strophe._xmlGenerator.createDocumentFragment();
                 for (i = 0; i < elem.childNodes.length; i++) {
-                    children.appendChild(Strophe.createHtml(elem.childNodes[i]));
+                    el.appendChild(Strophe.createHtml(elem.childNodes[i]));
                 }
-                return children;
             }
         } else if (elem.nodeType == Strophe.ElementType.FRAGMENT) {
-            el = document.createDocumentFragment();
+            el = Strophe._xmlGenerator.createDocumentFragment();
             for (i = 0; i < elem.childNodes.length; i++) {
                 el.appendChild(Strophe.createHtml(elem.childNodes[i]));
             }

--- a/src/core.js
+++ b/src/core.js
@@ -677,11 +677,18 @@ Strophe = {
                     {
                         attribute = Strophe.XHTML.attributes[tag][i];
                         value = elem.getAttribute(attribute);
+                        if(value === null || value === '' || value === false || value === 0)
+                        {
+                            continue;
+                        }
                         if(attribute == 'style' && typeof value == 'object')
                         {
-                            value = value.cssText; // we're dealing with IE, need to get CSS out
+                            if(typeof value.cssText != 'undefined')
+                            {
+                                value = value.cssText; // we're dealing with IE, need to get CSS out
+                            }
                         }
-                        if(!value.match(/0|null|undefined|false/) && value !== '')
+                        if(!value.match(/0|null|undefined|false/))
                         {
                             // filter out invalid css styles
                             if(attribute == 'style')

--- a/src/core.js
+++ b/src/core.js
@@ -1090,12 +1090,23 @@ Strophe.Builder.prototype = {
      */
     h: function (html)
     {
-        /* add a wrapper in case html is a standalone fragment */
-        html = Strophe.xmlHtmlNode('<body>' + html + '</body>');
+        var node = null;
+        /* add a wrapper in case html is an unenclosed fragment */
+        var html = Strophe.xmlHtmlNode('<body>' + html + '</body>');
         html = html.childNodes[0];
         while(html.childNodes.length > 0)
         {
-            this.node.appendChild(html.childNodes[0]);
+            if (document.importNode)
+            {
+                node = document.importNode(html.childNodes[0], true);
+                html.removeChild(html.childNodes[0]);
+                this.node.appendChild(node);
+                node = null;
+            }
+            else // IE doesn't have importNode
+            {
+                this.node.appendChild(html.childNodes[0]);
+            }
         }
         return this;
     }

--- a/src/core.js
+++ b/src/core.js
@@ -670,10 +670,15 @@ Strophe = {
                 try
                 {
                     el = Strophe.xmlElement(tag);
-                    for (i = 0; i < elem.attributes.length; i++) {
-                        attribute = elem.attributes[i].nodeName.toLowerCase();
-                        value = elem.attributes[i].value;
-                        if(Strophe.XHTML.validAttribute(tag, attribute) && !value.match(/0|null|undefined|false/) && value !== '')
+                    for(i = 0; i < Strophe.XHTML.attributes[tag].length; i++)
+                    {
+                        attribute = Strophe.XHTML.attributes[tag][i];
+                        value = elem.getAttribute(attribute);
+                        if(attribute == 'style' && typeof value == 'object')
+                        {
+                            value = value.cssText; // we're dealing with IE, need to get CSS out
+                        }
+                        if(!value.match(/0|null|undefined|false/) && value !== '')
                         {
                             // filter out invalid css styles
                             if(attribute == 'style')
@@ -708,29 +713,21 @@ Strophe = {
                     }
                 }
                 catch(e) { // invalid elements
-                  el = false;
+                  el = Strophe.xmlTextNode('');
                 }
             }
             else
             {
                 children = document.createDocumentFragment();
                 for (i = 0; i < elem.childNodes.length; i++) {
-                    child = Strophe.createHtml(elem.childNodes[i]);
-                    if(child !== false)
-                    {
-                        children.appendChild(child);
-                    }
+                    children.appendChild(Strophe.createHtml(elem.childNodes[i]));
                 }
                 return children;
             }
         } else if (elem.nodeType == Strophe.ElementType.FRAGMENT) {
             el = document.createDocumentFragment();
             for (i = 0; i < elem.childNodes.length; i++) {
-                child = Strophe.createHtml(elem.childNodes[i]);
-                if(child !== false)
-                {
-                    el.appendChild(child);
-                }
+                el.appendChild(Strophe.createHtml(elem.childNodes[i]));
             }
         } else if (elem.nodeType == Strophe.ElementType.TEXT) {
             el = Strophe.xmlTextNode(elem.nodeValue);

--- a/src/core.js
+++ b/src/core.js
@@ -981,7 +981,8 @@ Strophe = {
                 "='" + elem.attributes[i].value
                     .replace(/&/g, "&amp;")
                        .replace(/\'/g, "&apos;")
-                       .replace(/</g, "&lt;") + "'";
+                       .replace(/</g, "&lt;")
+                       .replace(/>/g, "&gt;") + "'";
                }
         }
 

--- a/src/core.js
+++ b/src/core.js
@@ -663,9 +663,6 @@ Strophe = {
     createHtml: function (elem)
     {
         var i, el, j, tag, attribute, value, css, cssAttrs, attr, cssName, cssValue, children, child;
-        if (!Strophe._xmlGenerator) {
-            Strophe._xmlGenerator = Strophe._makeGenerator();
-        }
         if (elem.nodeType == Strophe.ElementType.NORMAL) {
             tag = elem.nodeName.toLowerCase();
             if(Strophe.XHTML.validTag(tag))
@@ -728,13 +725,13 @@ Strophe = {
             }
             else
             {
-                el = Strophe._xmlGenerator.createDocumentFragment();
+                el = Strophe.xmlGenerator().createDocumentFragment();
                 for (i = 0; i < elem.childNodes.length; i++) {
                     el.appendChild(Strophe.createHtml(elem.childNodes[i]));
                 }
             }
         } else if (elem.nodeType == Strophe.ElementType.FRAGMENT) {
-            el = Strophe._xmlGenerator.createDocumentFragment();
+            el = Strophe.xmlGenerator().createDocumentFragment();
             for (i = 0; i < elem.childNodes.length; i++) {
                 el.appendChild(Strophe.createHtml(elem.childNodes[i]));
             }

--- a/src/core.js
+++ b/src/core.js
@@ -1090,11 +1090,16 @@ Strophe.Builder.prototype = {
      */
     h: function (html)
     {
-        this.node.textContent = html;
+        /* add a wrapper in case html is a standalone fragment */
+        html = Strophe.xmlHtmlNode('<body>' + html + '</body>');
+        html = html.childNodes[0];
+        while(html.childNodes.length > 0)
+        {
+            this.node.appendChild(html.childNodes[0]);
+        }
         return this;
     }
 };
-
 
 /** PrivateClass: Strophe.Handler
  *  _Private_ helper class for managing stanza handlers.

--- a/src/core.js
+++ b/src/core.js
@@ -176,6 +176,8 @@ Strophe = {
      *  NS.STREAM - XMPP Streams namespace from RFC 3920.
      *  NS.BIND - XMPP Binding namespace from RFC 3920.
      *  NS.SESSION - XMPP Session namespace from RFC 3920.
+     *  NS.XHTML_IM - XHTML-IM namespace from XEP 71.
+     *  NS.XHTML - XHTML body namespace from XEP 71.
      */
     NS: {
         HTTPBIND: "http://jabber.org/protocol/httpbind",
@@ -192,7 +194,9 @@ Strophe = {
         BIND: "urn:ietf:params:xml:ns:xmpp-bind",
         SESSION: "urn:ietf:params:xml:ns:xmpp-session",
         VERSION: "jabber:iq:version",
-        STANZAS: "urn:ietf:params:xml:ns:xmpp-stanzas"
+        STANZAS: "urn:ietf:params:xml:ns:xmpp-stanzas",
+        XHTML_IM: "http://jabber.org/protocol/xhtml-im",
+        XHTML: "http://www.w3.org/1999/xhtml"
     },
 
     /** Function: addNamespace
@@ -490,6 +494,32 @@ Strophe = {
 	text = Strophe.xmlescape(text);
 
         return Strophe.xmlGenerator().createTextNode(text);
+    },
+
+    /** Function: xmlHtmlNode
+     *  Creates an XML DOM html node.
+     *
+     *  Parameters:
+     *    (String) html - The content of the html node.
+     *
+     *  Returns:
+     *    A new XML DOM text node.
+     */
+    xmlHtmlNode: function (html)
+    {
+        //ensure text is escaped
+        if (window.DOMParser)
+        {
+            parser = new DOMParser();
+            node = parser.parseFromString(html, "text/xml");
+        }
+        else
+        {
+            node = new ActiveXObject("Microsoft.XMLDOM");
+            node.async="false";
+            node.loadXML(html);
+        }
+        return node;
     },
 
     /** Function: getText
@@ -1044,6 +1074,23 @@ Strophe.Builder.prototype = {
     {
         var child = Strophe.xmlTextNode(text);
         this.node.appendChild(child);
+        return this;
+    },
+
+    /** Function: h
+     *  Replace current element contents with the HTML passed in.
+     *
+     *  This *does not* make the child the new current element
+     *
+     *  Parameters:
+     *    (String) html - The html to insert as contents of current element.
+     *
+     *  Returns:
+     *    The Strophe.Builder object.
+     */
+    h: function (html)
+    {
+        this.node.textContent = html;
         return this;
     }
 };

--- a/src/core.js
+++ b/src/core.js
@@ -674,7 +674,7 @@ Strophe = {
                     {
                         attribute = Strophe.XHTML.attributes[tag][i];
                         value = elem.getAttribute(attribute);
-                        if(value === null || value === '' || value === false || value === 0)
+                        if(typeof value == 'undefined' || value === null || value === '' || value === false || value === 0)
                         {
                             continue;
                         }
@@ -685,33 +685,30 @@ Strophe = {
                                 value = value.cssText; // we're dealing with IE, need to get CSS out
                             }
                         }
-                        if(!value.match(/0|null|undefined|false/))
+                        // filter out invalid css styles
+                        if(attribute == 'style')
                         {
-                            // filter out invalid css styles
-                            if(attribute == 'style')
+                            css = [];
+                            cssAttrs = value.split(';');
+                            for(j = 0; j < cssAttrs.length; j++)
                             {
-                                css = [];
-                                cssAttrs = value.split(';');
-                                for(j = 0; j < cssAttrs.length; j++)
+                                attr = cssAttrs[j].split(':');
+                                cssName = attr[0].replace(/^\s*/, "").replace(/\s*$/, "").toLowerCase();
+                                if(Strophe.XHTML.validCSS(cssName))
                                 {
-                                    attr = cssAttrs[j].split(':');
-                                    cssName = attr[0].replace(/^\s*/, "").replace(/\s*$/, "").toLowerCase();
-                                    if(Strophe.XHTML.validCSS(cssName))
-                                    {
-                                        cssValue = attr[1].replace(/^\s*/, "").replace(/\s*$/, "");
-                                        css.push(cssName + ': ' + cssValue);
-                                    }
-                                }
-                                if(css.length > 0)
-                                {
-                                    value = css.join('; ');
-                                    el.setAttribute(attribute, value);
+                                    cssValue = attr[1].replace(/^\s*/, "").replace(/\s*$/, "");
+                                    css.push(cssName + ': ' + cssValue);
                                 }
                             }
-                            else
+                            if(css.length > 0)
                             {
+                                value = css.join('; ');
                                 el.setAttribute(attribute, value);
                             }
+                        }
+                        else
+                        {
+                            el.setAttribute(attribute, value);
                         }
                     }
 

--- a/src/core.js
+++ b/src/core.js
@@ -1091,22 +1091,11 @@ Strophe.Builder.prototype = {
     h: function (html)
     {
         var node = null;
-        /* add a wrapper in case html is an unenclosed fragment */
-        var html = Strophe.xmlHtmlNode('<body>' + html + '</body>');
-        html = html.childNodes[0];
-        while(html.childNodes.length > 0)
+        var fragment = document.createElement('div');
+        fragment.innerHTML = html;
+        while(fragment.childNodes.length > 0)
         {
-            if (document.importNode)
-            {
-                node = document.importNode(html.childNodes[0], true);
-                html.removeChild(html.childNodes[0]);
-                this.node.appendChild(node);
-                node = null;
-            }
-            else // IE doesn't have importNode
-            {
-                this.node.appendChild(html.childNodes[0]);
-            }
+            this.node.appendChild(fragment.childNodes[0]);
         }
         return this;
     }

--- a/src/core.js
+++ b/src/core.js
@@ -49,7 +49,7 @@ if (!Function.prototype.bind) {
         var _slice = Array.prototype.slice;
         var _concat = Array.prototype.concat;
         var _args = _slice.call(arguments, 1);
-        
+
         return function () {
             return func.apply(obj ? obj : this,
                               _concat.call(_args,
@@ -199,7 +199,70 @@ Strophe = {
         XHTML: "http://www.w3.org/1999/xhtml"
     },
 
-    /** Function: addNamespace
+
+    /** Constants: XHTML_IM Namespace 
+     *  contains allowed tags, tag attributes, and css properties. 
+     *  Used in the createHtml function to filter incoming html into the allowed XHTML-IM subset.
+     *  See http://xmpp.org/extensions/xep-0071.html#profile-summary for the list of recommended
+     *  allowed tags and their attributes.
+     */
+    XHTML: {
+		tags: ['a','blockquote','br','cite','em','img','li','ol','p','span','strong','ul','body'],
+		attributes: {
+			'a':          ['href'],
+			'blockquote': ['style'],
+			'br':         [],
+			'cite':       ['style'],
+			'em':         [],
+			'img':        ['src', 'alt', 'style', 'height', 'width'],
+			'li':         ['style'],
+			'ol':         ['style'],
+			'p':          ['style'],
+			'span':       ['style'],
+			'strong':     [],
+			'ul':         ['style'],
+			'body':       []
+		},
+		css: ['background-color','color','font-family','font-size','font-style','font-weight','margin-left','margin-right','text-align','text-decoration'],
+		validTag: function(tag)
+		{
+			for(var i = 0; i < Strophe.XHTML.tags.length; i++)
+			{
+				if(tag == Strophe.XHTML.tags[i])
+				{
+					return true;
+				}
+			}
+			return false;
+		},
+		validAttribute: function(tag, attribute)
+		{
+			if(typeof Strophe.XHTML.attributes[tag] !== 'undefined' && Strophe.XHTML.attributes[tag].length > 0)
+			{
+				for(var i = 0; i < Strophe.XHTML.attributes[tag].length; i++)
+				{
+					if(attribute == Strophe.XHTML.attributes[tag][i])
+					{
+						return true;
+					}
+				}
+			}
+			return false;
+		},
+		validCSS: function(style)
+		{
+			for(var i = 0; i < Strophe.XHTML.css.length; i++)
+			{
+				if(style == Strophe.XHTML.css[i])
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+    },
+
+    /** Function: addNamespace 
      *  This function is used to extend the current namespaces in
      *	Strophe.NS.  It takes a key and a value with the key being the
      *	name of the new namespace, with its actual value.
@@ -209,11 +272,11 @@ Strophe = {
      *  Parameters:
      *    (String) name - The name under which the namespace will be
      *      referenced under Strophe.NS
-     *    (String) value - The actual namespace.
+     *    (String) value - The actual namespace.	
      */
     addNamespace: function (name, value)
     {
-	Strophe.NS[name] = value;
+	    Strophe.NS[name] = value;
     },
 
     /** Constants: Connection Status Constants
@@ -269,6 +332,7 @@ Strophe = {
         NORMAL: 1,
         TEXT: 3,
         CDATA: 4
+        FRAGMENT: 11
     },
 
     /** PrivateConstants: Timeout Values
@@ -451,7 +515,7 @@ Strophe = {
                     if (arguments[a].hasOwnProperty(k)) {
                         node.setAttribute(k, arguments[a][k]);
                     }
-                }
+                } 
             }
         }
 
@@ -467,14 +531,14 @@ Strophe = {
      *	Returns:
      *      Escaped text.
      */
-    xmlescape: function(text)
+    xmlescape: function(text) 
     {
-        text = text.replace(/\&/g, "&amp;");
+	text = text.replace(/\&/g, "&amp;");
         text = text.replace(/</g,  "&lt;");
         text = text.replace(/>/g,  "&gt;");
         text = text.replace(/'/g,  "&apos;");
         text = text.replace(/"/g,  "&quot;");
-        return text;
+        return text;    
     },
 
     /** Function: xmlTextNode
@@ -584,7 +648,7 @@ Strophe = {
     },
 
 
-    /** Function: copyHtml
+    /** Function: createHtml
      *  Copy an HTML DOM element into an XML DOM.
      *
      *  This function copies a DOM element and all its descendants and returns
@@ -596,27 +660,77 @@ Strophe = {
      *  Returns:
      *    A new, copied DOM element tree.
      */
-    copyHtml: function (elem)
+    createHtml: function (elem)
     {
-        var i, el;
+        var i, el, j, tag, attribute, value, css, cssAttrs, attr, cssName, cssValue, children, child;
         if (elem.nodeType == Strophe.ElementType.NORMAL) {
-            try
+            tag = elem.nodeName.toLowerCase();
+            if(Strophe.XHTML.validTag(tag))
             {
-                el = Strophe.xmlElement(elem.tagName);
-                for (i = 0; i < elem.attributes.length; i++) {
-                    if(elem.attributes[i].nodeName.toLowerCase().match(/href|src|target/) && !elem.attributes[i].value.match(/0|null|undefined|false/) && elem.attributes[i].value !== '')
-                    {
-                        el.setAttribute(elem.attributes[i].nodeName.toLowerCase(),
-                                elem.attributes[i].value);
+                try
+                {
+                    el = Strophe.xmlElement(tag);
+                    for (i = 0; i < elem.attributes.length; i++) {
+                        attribute = elem.attributes[i].nodeName.toLowerCase();
+                        value = elem.attributes[i].value;
+                        if(Strophe.XHTML.validAttribute(tag, attribute) && !value.match(/0|null|undefined|false/) && value !== '')
+                        {
+                            // filter out invalid css styles
+                            if(attribute == 'style')
+                            {
+                                css = [];
+                                cssAttrs = value.split(';');
+                                for(j = 0; j < cssAttrs.length; j++)
+                                {
+                                    attr = cssAttrs[j].split(':');
+                                    cssName = attr[0].replace(/^\s*/, "").replace(/\s*$/, "").toLowerCase();
+                                    if(Strophe.XHTML.validCSS(cssName))
+                                    {
+                                        cssValue = attr[1].replace(/^\s*/, "").replace(/\s*$/, "");
+                                        css.push(cssName + ': ' + cssValue);
+                                    }
+                                }
+                                if(css.length > 0)
+                                {
+                                    value = css.join('; ');
+                                    el.setAttribute(attribute, value);
+                                }
+                            }
+                            else
+                            {
+                                el.setAttribute(attribute, value);
+                            }
+                        }
+                    }
+
+                    for (i = 0; i < elem.childNodes.length; i++) {
+                        el.appendChild(Strophe.createHtml(elem.childNodes[i]));
                     }
                 }
-
-                for (i = 0; i < elem.childNodes.length; i++) {
-                    el.appendChild(Strophe.copyHtml(elem.childNodes[i]));
+                catch(e) { // invalid elements
+                  el = false;
                 }
             }
-            catch(e) { // invalid elements
-              el = Strophe.xmlTextNode('');
+            else
+            {
+                children = document.createDocumentFragment();
+                for (i = 0; i < elem.childNodes.length; i++) {
+                    child = Strophe.createHtml(elem.childNodes[i]);
+                    if(child !== false)
+                    {
+                        children.appendChild(child);
+                    }
+                }
+                return children;
+            }
+        } else if (elem.nodeType == Strophe.ElementType.FRAGMENT) {
+            el = document.createDocumentFragment();
+            for (i = 0; i < elem.childNodes.length; i++) {
+                child = Strophe.createHtml(elem.childNodes[i]);
+                if(child !== false)
+                {
+                    el.appendChild(child);
+                }
             }
         } else if (elem.nodeType == Strophe.ElementType.TEXT) {
             el = Strophe.xmlTextNode(elem.nodeValue);
@@ -1132,14 +1246,13 @@ Strophe.Builder.prototype = {
      */
     h: function (html)
     {
-        var fragment = document.createDocumentFragment();
-        fragment.appendChild(document.createElement('div'));
+        var fragment = document.createElement('body');
 
         // force the browser to try and fix any invalid HTML tags
-        fragment.childNodes[0].innerHTML = html;
+        fragment.innerHTML = html;
 
         // copy cleaned html into an xml dom
-        var xhtml = Strophe.copyHtml(fragment.childNodes[0]);
+        var xhtml = Strophe.createHtml(fragment);
 
         while(xhtml.childNodes.length > 0)
         {
@@ -1186,7 +1299,7 @@ Strophe.Handler = function (handler, ns, name, type, id, from, options)
     this.type = type;
     this.id = id;
     this.options = options || {matchbare: false};
-
+    
     // default matchBare to false if undefined
     if (!this.options.matchBare) {
         this.options.matchBare = false;
@@ -1216,7 +1329,7 @@ Strophe.Handler.prototype = {
     {
         var nsMatch;
         var from = null;
-
+        
         if (this.options.matchBare) {
             from = Strophe.getBareJidFromJid(elem.getAttribute('from'));
         } else {
@@ -1871,10 +1984,10 @@ Strophe.Connection.prototype = {
 
     /** Function: flush
      *  Immediately send any pending outgoing data.
-     *
+     *  
      *  Normally send() queues outgoing data until the next idle period
      *  (100ms), which optimizes network use in the common cases when
-     *  several send()s are called in succession. flush() can be used to
+     *  several send()s are called in succession. flush() can be used to 
      *  immediately send all pending data.
      */
     flush: function ()
@@ -1891,9 +2004,9 @@ Strophe.Connection.prototype = {
      *  Parameters:
      *    (XMLElement) elem - The stanza to send.
      *    (Function) callback - The callback function for a successful request.
-     *    (Function) errback - The callback function for a failed or timed
+     *    (Function) errback - The callback function for a failed or timed 
      *      out request.  On timeout, the stanza will be null.
-     *    (Integer) timeout - The time specified in milliseconds for a
+     *    (Integer) timeout - The time specified in milliseconds for a 
      *      timeout to occur.
      *
      *  Returns:
@@ -1969,7 +2082,7 @@ Strophe.Connection.prototype = {
                 message: "Cannot queue non-DOMElement."
             };
         }
-
+        
         this._data.push(element);
     },
 
@@ -2052,7 +2165,7 @@ Strophe.Connection.prototype = {
      *  boolean). When matchBare is true, the from parameter and the from
      *  attribute on the stanza will be matched as bare JIDs instead of
      *  full JIDs. To use this, pass {matchBare: true} as the value of
-     *  options. The default value for matchBare is false.
+     *  options. The default value for matchBare is false. 
      *
      *  The return value should be saved if you wish to remove the handler
      *  with deleteHandler().
@@ -2695,7 +2808,7 @@ Strophe.Connection.prototype = {
         if (hold) { this.hold = parseInt(hold, 10); }
         var wait = bodyWrap.getAttribute('wait');
         if (wait) { this.wait = parseInt(wait, 10); }
-
+        
 
         var do_sasl_plain = false;
         var do_sasl_digest_md5 = false;
@@ -2895,7 +3008,7 @@ Strophe.Connection.prototype = {
      */
     _quote: function (str)
     {
-        return '"' + str.replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"';
+        return '"' + str.replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"'; 
         //" end string workaround for emacs
     },
 

--- a/src/core.js
+++ b/src/core.js
@@ -226,10 +226,8 @@ Strophe = {
 		css: ['background-color','color','font-family','font-size','font-style','font-weight','margin-left','margin-right','text-align','text-decoration'],
 		validTag: function(tag)
 		{
-			for(var i = 0; i < Strophe.XHTML.tags.length; i++)
-			{
-				if(tag == Strophe.XHTML.tags[i])
-				{
+			for(var i = 0; i < Strophe.XHTML.tags.length; i++) {
+				if(tag == Strophe.XHTML.tags[i]) {
 					return true;
 				}
 			}
@@ -237,12 +235,9 @@ Strophe = {
 		},
 		validAttribute: function(tag, attribute)
 		{
-			if(typeof Strophe.XHTML.attributes[tag] !== 'undefined' && Strophe.XHTML.attributes[tag].length > 0)
-			{
-				for(var i = 0; i < Strophe.XHTML.attributes[tag].length; i++)
-				{
-					if(attribute == Strophe.XHTML.attributes[tag][i])
-					{
+			if(typeof Strophe.XHTML.attributes[tag] !== 'undefined' && Strophe.XHTML.attributes[tag].length > 0) {
+				for(var i = 0; i < Strophe.XHTML.attributes[tag].length; i++) {
+					if(attribute == Strophe.XHTML.attributes[tag][i]) {
 						return true;
 					}
 				}
@@ -251,10 +246,8 @@ Strophe = {
 		},
 		validCSS: function(style)
 		{
-			for(var i = 0; i < Strophe.XHTML.css.length; i++)
-			{
-				if(style == Strophe.XHTML.css[i])
-				{
+			for(var i = 0; i < Strophe.XHTML.css.length; i++) {
+				if(style == Strophe.XHTML.css[i]) {
 					return true;
 				}
 			}
@@ -272,7 +265,7 @@ Strophe = {
      *  Parameters:
      *    (String) name - The name under which the namespace will be
      *      referenced under Strophe.NS
-     *    (String) value - The actual namespace.	
+     *    (String) value - The actual namespace.
      */
     addNamespace: function (name, value)
     {
@@ -327,6 +320,7 @@ Strophe = {
      *
      *  ElementType.NORMAL - Normal element.
      *  ElementType.TEXT - Text data element.
+     *  ElementType.FRAGMENT - XHTML fragment element.
      */
     ElementType: {
         NORMAL: 1,
@@ -515,7 +509,7 @@ Strophe = {
                     if (arguments[a].hasOwnProperty(k)) {
                         node.setAttribute(k, arguments[a][k]);
                     }
-                } 
+                }
             }
         }
 
@@ -531,14 +525,14 @@ Strophe = {
      *	Returns:
      *      Escaped text.
      */
-    xmlescape: function(text) 
+    xmlescape: function(text)
     {
-	text = text.replace(/\&/g, "&amp;");
+        text = text.replace(/\&/g, "&amp;");
         text = text.replace(/</g,  "&lt;");
         text = text.replace(/>/g,  "&gt;");
         text = text.replace(/'/g,  "&apos;");
         text = text.replace(/"/g,  "&quot;");
-        return text;    
+        return text;
     },
 
     /** Function: xmlTextNode
@@ -572,13 +566,10 @@ Strophe = {
     xmlHtmlNode: function (html)
     {
         //ensure text is escaped
-        if (window.DOMParser)
-        {
+        if (window.DOMParser) {
             parser = new DOMParser();
             node = parser.parseFromString(html, "text/xml");
-        }
-        else
-        {
+        } else {
             node = new ActiveXObject("Microsoft.XMLDOM");
             node.async="false";
             node.loadXML(html);
@@ -665,49 +656,37 @@ Strophe = {
         var i, el, j, tag, attribute, value, css, cssAttrs, attr, cssName, cssValue, children, child;
         if (elem.nodeType == Strophe.ElementType.NORMAL) {
             tag = elem.nodeName.toLowerCase();
-            if(Strophe.XHTML.validTag(tag))
-            {
-                try
-                {
+            if(Strophe.XHTML.validTag(tag)) {
+                try {
                     el = Strophe.xmlElement(tag);
-                    for(i = 0; i < Strophe.XHTML.attributes[tag].length; i++)
-                    {
+                    for(i = 0; i < Strophe.XHTML.attributes[tag].length; i++) {
                         attribute = Strophe.XHTML.attributes[tag][i];
                         value = elem.getAttribute(attribute);
-                        if(typeof value == 'undefined' || value === null || value === '' || value === false || value === 0)
-                        {
+                        if(typeof value == 'undefined' || value === null || value === '' || value === false || value === 0) {
                             continue;
                         }
-                        if(attribute == 'style' && typeof value == 'object')
-                        {
-                            if(typeof value.cssText != 'undefined')
-                            {
+                        if(attribute == 'style' && typeof value == 'object') {
+                            if(typeof value.cssText != 'undefined') {
                                 value = value.cssText; // we're dealing with IE, need to get CSS out
                             }
                         }
                         // filter out invalid css styles
-                        if(attribute == 'style')
-                        {
+                        if(attribute == 'style') {
                             css = [];
                             cssAttrs = value.split(';');
-                            for(j = 0; j < cssAttrs.length; j++)
-                            {
+                            for(j = 0; j < cssAttrs.length; j++) {
                                 attr = cssAttrs[j].split(':');
                                 cssName = attr[0].replace(/^\s*/, "").replace(/\s*$/, "").toLowerCase();
-                                if(Strophe.XHTML.validCSS(cssName))
-                                {
+                                if(Strophe.XHTML.validCSS(cssName)) {
                                     cssValue = attr[1].replace(/^\s*/, "").replace(/\s*$/, "");
                                     css.push(cssName + ': ' + cssValue);
                                 }
                             }
-                            if(css.length > 0)
-                            {
+                            if(css.length > 0) {
                                 value = css.join('; ');
                                 el.setAttribute(attribute, value);
                             }
-                        }
-                        else
-                        {
+                        } else {
                             el.setAttribute(attribute, value);
                         }
                     }
@@ -715,13 +694,10 @@ Strophe = {
                     for (i = 0; i < elem.childNodes.length; i++) {
                         el.appendChild(Strophe.createHtml(elem.childNodes[i]));
                     }
-                }
-                catch(e) { // invalid elements
+                } catch(e) { // invalid elements
                   el = Strophe.xmlTextNode('');
                 }
-            }
-            else
-            {
+            } else {
                 el = Strophe.xmlGenerator().createDocumentFragment();
                 for (i = 0; i < elem.childNodes.length; i++) {
                     el.appendChild(Strophe.createHtml(elem.childNodes[i]));
@@ -975,8 +951,8 @@ Strophe = {
                 "='" + elem.attributes[i].value
                     .replace(/&/g, "&amp;")
                        .replace(/\'/g, "&apos;")
-                       .replace(/</g, "&lt;")
-                       .replace(/>/g, "&gt;") + "'";
+                       .replace(/>/g, "&gt;")
+                       .replace(/</g, "&lt;") + "'";
                }
         }
 
@@ -1255,8 +1231,7 @@ Strophe.Builder.prototype = {
         // copy cleaned html into an xml dom
         var xhtml = Strophe.createHtml(fragment);
 
-        while(xhtml.childNodes.length > 0)
-        {
+        while(xhtml.childNodes.length > 0) {
             this.node.appendChild(xhtml.childNodes[0]);
         }
         return this;
@@ -1985,10 +1960,10 @@ Strophe.Connection.prototype = {
 
     /** Function: flush
      *  Immediately send any pending outgoing data.
-     *  
+     *
      *  Normally send() queues outgoing data until the next idle period
      *  (100ms), which optimizes network use in the common cases when
-     *  several send()s are called in succession. flush() can be used to 
+     *  several send()s are called in succession. flush() can be used to
      *  immediately send all pending data.
      */
     flush: function ()
@@ -2005,9 +1980,9 @@ Strophe.Connection.prototype = {
      *  Parameters:
      *    (XMLElement) elem - The stanza to send.
      *    (Function) callback - The callback function for a successful request.
-     *    (Function) errback - The callback function for a failed or timed 
+     *    (Function) errback - The callback function for a failed or timed
      *      out request.  On timeout, the stanza will be null.
-     *    (Integer) timeout - The time specified in milliseconds for a 
+     *    (Integer) timeout - The time specified in milliseconds for a
      *      timeout to occur.
      *
      *  Returns:
@@ -2166,7 +2141,7 @@ Strophe.Connection.prototype = {
      *  boolean). When matchBare is true, the from parameter and the from
      *  attribute on the stanza will be matched as bare JIDs instead of
      *  full JIDs. To use this, pass {matchBare: true} as the value of
-     *  options. The default value for matchBare is false. 
+     *  options. The default value for matchBare is false.
      *
      *  The return value should be saved if you wish to remove the handler
      *  with deleteHandler().
@@ -3009,7 +2984,7 @@ Strophe.Connection.prototype = {
      */
     _quote: function (str)
     {
-        return '"' + str.replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"'; 
+        return '"' + str.replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"';
         //" end string workaround for emacs
     },
 

--- a/src/core.js
+++ b/src/core.js
@@ -325,7 +325,7 @@ Strophe = {
     ElementType: {
         NORMAL: 1,
         TEXT: 3,
-        CDATA: 4
+        CDATA: 4,
         FRAGMENT: 11
     },
 


### PR DESCRIPTION
This adds support for generating and passing valid xhtml-formatted messages alongside the plaintext messages. Useful if you want to allow users to use styling in their messages.

This is based on the work I did for my day job, cleaned up and rebased off latest version of strophejs.
