### PR TITLE
IE9 memory leak fix from Google Groups discussion

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -404,7 +404,11 @@ Strophe = {
     _makeGenerator: function () {
         var doc;
 
-        if (document.implementation.createDocument === undefined) {
+        // IE9 does implement createDocument(); however, using it will cause the browser to leak memory on page unload.
+        // Here, we test for presence of createDocument() plus IE's proprietary documentMode attribute, which would be 
+		// less than 10 in the case of IE9 and below.
+        if (document.implementation.createDocument === undefined || 
+			document.implementation.createDocument && document.documentMode && document.documentMode < 10)) {
             doc = this._getIEXmlDom();
             doc.appendChild(doc.createElement('strophe'));
         } else {


### PR DESCRIPTION
This patch forces IE9 to take the _getIEXmlDom() branch in Strophe._makeGenerator to avoid a memory leak caused by using the W3C standard way of creating Documents via document.implementation.createDocument( ).
