### PR TITLE
Fix qunit deprecation warnings and CSS

### DIFF
--- a/tests/strophe.html
+++ b/tests/strophe.html
@@ -10,9 +10,9 @@
 
     <script src="http://code.jquery.com/jquery-latest.js"></script>
     <link rel="stylesheet"
-          href="https://github.com/jquery/qunit/raw/master/qunit/qunit.css"
+          href="http://code.jquery.com/qunit/qunit-git.css"
           type="text/css">
-    <script src="https://github.com/jquery/qunit/raw/master/qunit/qunit.js"></script>
+    <script src="http://code.jquery.com/qunit/qunit-git.js"></script>
     <script src="http://cjohansen.no/sinon/releases/sinon-0.8.0.js"></script>
     <script src="http://cjohansen.no/sinon/releases/sinon-qunit-0.8.0.js"></script>
     <script src='../strophe.js'></script>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -3,27 +3,27 @@ $(document).ready(function () {
 
     test("Normal JID", function () {
         var jid = "darcy@pemberley.lit/library";
-        equals(Strophe.getNodeFromJid(jid), "darcy",
+        equal(Strophe.getNodeFromJid(jid), "darcy",
                "Node should be 'darcy'");
-        equals(Strophe.getDomainFromJid(jid), "pemberley.lit",
+        equal(Strophe.getDomainFromJid(jid), "pemberley.lit",
                "Domain should be 'pemberley.lit'");
-        equals(Strophe.getResourceFromJid(jid), "library",
+        equal(Strophe.getResourceFromJid(jid), "library",
                "Node should be 'library'");
-        equals(Strophe.getBareJidFromJid(jid),
+        equal(Strophe.getBareJidFromJid(jid),
                "darcy@pemberley.lit",
                "Bare JID should be 'darcy@pemberley.lit'");
     });
 
     test("Weird node (unescaped)", function () {
         var jid = "darcy@netherfield.lit@pemberley.lit/library";
-        equals(Strophe.getNodeFromJid(jid), "darcy",
+        equal(Strophe.getNodeFromJid(jid), "darcy",
                "Node should be 'darcy'");
-        equals(Strophe.getDomainFromJid(jid),
+        equal(Strophe.getDomainFromJid(jid),
                "netherfield.lit@pemberley.lit",
                "Domain should be 'netherfield.lit@pemberley.lit'");
-        equals(Strophe.getResourceFromJid(jid), "library",
+        equal(Strophe.getResourceFromJid(jid), "library",
                "Resource should be 'library'");
-        equals(Strophe.getBareJidFromJid(jid),
+        equal(Strophe.getBareJidFromJid(jid),
                "darcy@netherfield.lit@pemberley.lit",
                "Bare JID should be 'darcy@netherfield.lit@pemberley.lit'");
     });
@@ -31,28 +31,28 @@ $(document).ready(function () {
     test("Weird node (escaped)", function () {
         var escapedNode = Strophe.escapeNode("darcy@netherfield.lit");
         var jid = escapedNode + "@pemberley.lit/library";
-        equals(Strophe.getNodeFromJid(jid), "darcy\\40netherfield.lit",
+        equal(Strophe.getNodeFromJid(jid), "darcy\\40netherfield.lit",
                "Node should be 'darcy\\40netherfield.lit'");
-        equals(Strophe.getDomainFromJid(jid),
+        equal(Strophe.getDomainFromJid(jid),
                "pemberley.lit",
                "Domain should be 'pemberley.lit'");
-        equals(Strophe.getResourceFromJid(jid), "library",
+        equal(Strophe.getResourceFromJid(jid), "library",
                "Resource should be 'library'");
-        equals(Strophe.getBareJidFromJid(jid),
+        equal(Strophe.getBareJidFromJid(jid),
                "darcy\\40netherfield.lit@pemberley.lit",
                "Bare JID should be 'darcy\\40netherfield.lit@pemberley.lit'");
     });
 
     test("Weird resource", function () {
         var jid = "books@chat.pemberley.lit/darcy@pemberley.lit/library";
-        equals(Strophe.getNodeFromJid(jid), "books",
+        equal(Strophe.getNodeFromJid(jid), "books",
                "Node should be 'books'");
-        equals(Strophe.getDomainFromJid(jid), "chat.pemberley.lit",
+        equal(Strophe.getDomainFromJid(jid), "chat.pemberley.lit",
                "Domain should be 'chat.pemberley.lit'");
-        equals(Strophe.getResourceFromJid(jid),
+        equal(Strophe.getResourceFromJid(jid),
                "darcy@pemberley.lit/library",
                "Resource should be 'darcy@pemberley.lit/library'");
-        equals(Strophe.getBareJidFromJid(jid),
+        equal(Strophe.getBareJidFromJid(jid),
                "books@chat.pemberley.lit",
                "Bare JID should be 'books@chat.pemberley.lit'");
     });
@@ -64,7 +64,7 @@ $(document).ready(function () {
                        $build("iq", {}).tree(),
                        $pres().tree()];
         $.each(stanzas, function () {
-            equals($(this).attr('xmlns'), Strophe.NS.CLIENT,
+            equal($(this).attr('xmlns'), Strophe.NS.CLIENT,
                   "Namespace should be '" + Strophe.NS.CLIENT + "'");
         });
     });
@@ -91,7 +91,7 @@ $(document).ready(function () {
         try {
             conn.send(stanza);
         } catch (e) {
-            equals(e.name, "StropheError", "send() should throw exception");
+            equal(e.name, "StropheError", "send() should throw exception");
         }
     });
 
@@ -99,19 +99,19 @@ $(document).ready(function () {
         var text = "<b>";
         var expected = "<presence to='&lt;b&gt;' xmlns='jabber:client'/>";
         var pres = $pres({to: text});
-        equals(pres.toString(), expected, "< should be escaped");
+        equal(pres.toString(), expected, "< should be escaped");
 
         text = "foo&bar";
         expected = "<presence to='foo&amp;bar' xmlns='jabber:client'/>";
         pres = $pres({to: text});
-        equals(pres.toString(), expected, "& should be escaped");
+        equal(pres.toString(), expected, "& should be escaped");
     });
 
     test("c() accepts text and passes it to xmlElement", function () {
         var pres = $pres({from: "darcy@pemberley.lit", to: "books@chat.pemberley.lit"})
             .c("nick", {xmlns: "http://jabber.org/protocol/nick"}, "Darcy");
         var expected = "<presence from='darcy@pemberley.lit' to='books@chat.pemberley.lit' xmlns='jabber:client'><nick xmlns='http://jabber.org/protocol/nick'>Darcy</nick></presence>";
-        equals(pres.toString(), expected, "'Darcy' should be a child of <presence>");
+        equal(pres.toString(), expected, "'Darcy' should be a child of <presence>");
     });
 
     module("XML");
@@ -119,65 +119,65 @@ $(document).ready(function () {
     test("XML escaping test", function () {
         var text = "s & p";
         var textNode = Strophe.xmlTextNode(text);
-        equals(Strophe.getText(textNode), "s &amp; p", "should be escaped");
+        equal(Strophe.getText(textNode), "s &amp; p", "should be escaped");
         var text0 = "s < & > p";
         var textNode0 = Strophe.xmlTextNode(text0);
-        equals(Strophe.getText(textNode0), "s &lt; &amp; &gt; p", "should be escaped");
+        equal(Strophe.getText(textNode0), "s &lt; &amp; &gt; p", "should be escaped");
         var text1 = "s's or \"p\"";
         var textNode1 = Strophe.xmlTextNode(text1);
-        equals(Strophe.getText(textNode1), "s&apos;s or &quot;p&quot;", "should be escaped");
+        equal(Strophe.getText(textNode1), "s&apos;s or &quot;p&quot;", "should be escaped");
         var text2 = "<![CDATA[<foo>]]>";
         var textNode2 = Strophe.xmlTextNode(text2);
-        equals(Strophe.getText(textNode2), "&lt;![CDATA[&lt;foo&gt;]]&gt;", "should be escaped");
+        equal(Strophe.getText(textNode2), "&lt;![CDATA[&lt;foo&gt;]]&gt;", "should be escaped");
         var text3 = "<![CDATA[]]]]><![CDATA[>]]>";
         var textNode3 = Strophe.xmlTextNode(text3);
-        equals(Strophe.getText(textNode3), "&lt;![CDATA[]]]]&gt;&lt;![CDATA[&gt;]]&gt;", "should be escaped");
+        equal(Strophe.getText(textNode3), "&lt;![CDATA[]]]]&gt;&lt;![CDATA[&gt;]]&gt;", "should be escaped");
         var text4 = "&lt;foo&gt;<![CDATA[<foo>]]>";
         var textNode4 = Strophe.xmlTextNode(text4);
-        equals(Strophe.getText(textNode4), "&amp;lt;foo&amp;gt;&lt;![CDATA[&lt;foo&gt;]]&gt;", "should be escaped");
+        equal(Strophe.getText(textNode4), "&amp;lt;foo&amp;gt;&lt;![CDATA[&lt;foo&gt;]]&gt;", "should be escaped");
     });
 
     test("XML element creation", function () {
         var elem = Strophe.xmlElement("message");
-        equals(elem.tagName, "message", "Element name should be the same");
+        equal(elem.tagName, "message", "Element name should be the same");
     });
 
     test("copyElement() double escape bug", function() {
         var cloned = Strophe.copyElement(Strophe.xmlGenerator()
                                          .createTextNode('<>&lt;&gt;'));
-        equals(cloned.nodeValue, '<>&lt;&gt;');
+        equal(cloned.nodeValue, '<>&lt;&gt;');
     });
     
     test("XML serializing", function() {
         var parser = new DOMParser();
         // Attributes
         var element1 = parser.parseFromString("<foo attr1='abc' attr2='edf'>bar</foo>","text/xml").documentElement;
-        equals(Strophe.serialize(element1), "<foo attr1='abc' attr2='edf'>bar</foo>", "should be serialized");
+        equal(Strophe.serialize(element1), "<foo attr1='abc' attr2='edf'>bar</foo>", "should be serialized");
         var element2 = parser.parseFromString("<foo attr1=\"abc\" attr2=\"edf\">bar</foo>","text/xml").documentElement;
-        equals(Strophe.serialize(element2), "<foo attr1='abc' attr2='edf'>bar</foo>", "should be serialized");
+        equal(Strophe.serialize(element2), "<foo attr1='abc' attr2='edf'>bar</foo>", "should be serialized");
         // Escaping values
         var element3 = parser.parseFromString("<foo>a &gt; &apos;b&apos; &amp; &quot;b&quot; &lt; c</foo>","text/xml").documentElement;
-        equals(Strophe.serialize(element3), "<foo>a &gt; &apos;b&apos; &amp; &quot;b&quot; &lt; c</foo>", "should be serialized");
+        equal(Strophe.serialize(element3), "<foo>a &gt; &apos;b&apos; &amp; &quot;b&quot; &lt; c</foo>", "should be serialized");
         // Escaping attributes
         var element4 = parser.parseFromString("<foo attr='&lt;a> &apos;b&apos;'>bar</foo>","text/xml").documentElement;
-        equals(Strophe.serialize(element4), "<foo attr='&lt;a&gt; &apos;b&apos;'>bar</foo>", "should be serialized");
+        equal(Strophe.serialize(element4), "<foo attr='&lt;a&gt; &apos;b&apos;'>bar</foo>", "should be serialized");
         var element5 = parser.parseFromString("<foo attr=\"&lt;a> &quot;b&quot;\">bar</foo>","text/xml").documentElement;
-        equals(Strophe.serialize(element5), "<foo attr='&lt;a&gt; \"b\"'>bar</foo>", "should be serialized");
+        equal(Strophe.serialize(element5), "<foo attr='&lt;a&gt; \"b\"'>bar</foo>", "should be serialized");
         // Empty elements
         var element6 = parser.parseFromString("<foo><empty></empty></foo>","text/xml").documentElement;
-        equals(Strophe.serialize(element6), "<foo><empty/></foo>", "should be serialized");
+        equal(Strophe.serialize(element6), "<foo><empty/></foo>", "should be serialized");
         // Children
         var element7 = parser.parseFromString("<foo><bar>a</bar><baz><wibble>b</wibble></baz></foo>","text/xml").documentElement;
-        equals(Strophe.serialize(element7), "<foo><bar>a</bar><baz><wibble>b</wibble></baz></foo>", "should be serialized");
+        equal(Strophe.serialize(element7), "<foo><bar>a</bar><baz><wibble>b</wibble></baz></foo>", "should be serialized");
         var element8 = parser.parseFromString("<foo><bar>a</bar><baz>b<wibble>c</wibble>d</baz></foo>","text/xml").documentElement;
-        equals(Strophe.serialize(element8), "<foo><bar>a</bar><baz>b<wibble>c</wibble>d</baz></foo>", "should be serialized");
+        equal(Strophe.serialize(element8), "<foo><bar>a</bar><baz>b<wibble>c</wibble>d</baz></foo>", "should be serialized");
         // CDATA
         var element9 = parser.parseFromString("<foo><![CDATA[<foo>]]></foo>","text/xml").documentElement;
-        equals(Strophe.serialize(element9), "<foo><![CDATA[<foo>]]></foo>", "should be serialized");
+        equal(Strophe.serialize(element9), "<foo><![CDATA[<foo>]]></foo>", "should be serialized");
         var element10 = parser.parseFromString("<foo><![CDATA[]]]]><![CDATA[>]]></foo>","text/xml").documentElement;
-        equals(Strophe.serialize(element10), "<foo><![CDATA[]]]]><![CDATA[>]]></foo>", "should be serialized");
+        equal(Strophe.serialize(element10), "<foo><![CDATA[]]]]><![CDATA[>]]></foo>", "should be serialized");
         var element11 = parser.parseFromString("<foo>&lt;foo&gt;<![CDATA[<foo>]]></foo>","text/xml").documentElement;
-        equals(Strophe.serialize(element11), "<foo>&lt;foo&gt;<![CDATA[<foo>]]></foo>", "should be serialized");
+        equal(Strophe.serialize(element11), "<foo>&lt;foo&gt;<![CDATA[<foo>]]></foo>", "should be serialized");
     });
 
     module("Handler");
@@ -187,11 +187,11 @@ $(document).ready(function () {
         
         var hand = new Strophe.Handler(null, null, null, null, null,
                                        'darcy@pemberley.lit/library');
-        equals(hand.isMatch(elem), true, "Full JID should match");
+        equal(hand.isMatch(elem), true, "Full JID should match");
 
         hand = new Strophe.Handler(null, null, null, null, null,
                                        'darcy@pemberley.lit')
-        equals(hand.isMatch(elem), false, "Bare JID shouldn't match");
+        equal(hand.isMatch(elem), false, "Bare JID shouldn't match");
     });
 
     test("Bare JID matching", function () {
@@ -200,12 +200,12 @@ $(document).ready(function () {
         var hand = new Strophe.Handler(null, null, null, null, null,
                                        'darcy@pemberley.lit/library',
                                        {matchBare: true});
-        equals(hand.isMatch(elem), true, "Full JID should match");
+        equal(hand.isMatch(elem), true, "Full JID should match");
         
         hand = new Strophe.Handler(null, null, null, null, null,
                                    'darcy@pemberley.lit',
                                    {matchBare: true});
-        equals(hand.isMatch(elem), true, "Bare JID should match");
+        equal(hand.isMatch(elem), true, "Bare JID should match");
     });
     
     module("Misc");
@@ -214,7 +214,7 @@ $(document).ready(function () {
         var input = '"beep \\40"';
         var conn = new Strophe.Connection();
         var output = conn._quote(input);
-        equals(output, "\"\\\"beep \\\\40\\\"\"",
+        equal(output, "\"\\\"beep \\\\40\\\"\"",
                "string should be quoted and escaped");
     });
 
@@ -227,10 +227,10 @@ $(document).ready(function () {
 
         var f = spy.bind(obj, arg1, arg2);
         f(arg3);
-        equals(spy.called, true, "bound function should be called");
-        equals(spy.calledOn(obj), true,
+        equal(spy.called, true, "bound function should be called");
+        equal(spy.calledOn(obj), true,
                "bound function should have correct context");
-        equals(spy.alwaysCalledWithExactly(arg1, arg2, arg3),
+        equal(spy.alwaysCalledWithExactly(arg1, arg2, arg3),
                true,
                "bound function should get all arguments");
     });
@@ -257,9 +257,9 @@ $(document).ready(function () {
 
         conn._onRequestStateChange(spy, req);
 
-        equals(req.abort, false, "abort flag should be toggled");
-        equals(conn._requests.length, 1, "_requests should be same length");
-        equals(spy.called, false, "callback should not be called");
+        equal(req.abort, false, "abort flag should be toggled");
+        equal(conn._requests.length, 1, "_requests should be same length");
+        equal(spy.called, false, "callback should not be called");
     });
 
     test("Incomplete requests do nothing", function () {
@@ -279,7 +279,7 @@ $(document).ready(function () {
 
         conn._onRequestStateChange(spy, req);
 
-        equals(conn._requests.length, 1, "_requests should be same length");
-        equals(spy.called, false, "callback should not be called");
+        equal(conn._requests.length, 1, "_requests should be same length");
+        equal(spy.called, false, "callback should not be called");
     });
 });


### PR DESCRIPTION
I noticed the qunit tests were failing due to deprecation warnings, and also the CSS wasn't being loaded properly due to the mime type Github now uses when serving files. I have fixed these two problems.
