### PR TITLE
Catch exception when something very bad happens like trying to log a document element.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1524,8 +1524,10 @@ Strophe.Request.prototype = {
             if (node.tagName == "parsererror") {
                 Strophe.error("invalid response received");
                 Strophe.error("responseText: " + this.xhr.responseText);
-                Strophe.error("responseXML: " +
-                              Strophe.serialize(this.xhr.responseXML));
+                try {
+                        Strophe.error("responseXML: " +
+                                Strophe.serialize(this.xhr.responseXML));
+                } catch(e) {}
                 throw "parsererror";
             }
         } else if (this.xhr.responseText) {


### PR DESCRIPTION
Logging responseText should be enough as a first step to discover what's wrong.
