### PR TITLE
Introduction of this.maxRetries for number of retries is not used in _onRequestStateChange

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2514,7 +2514,7 @@ Strophe.Connection.prototype = {
             var reqIs0 = (this._requests[0] == req);
             var reqIs1 = (this._requests[1] == req);
 
-            if ((reqStatus > 0 && reqStatus < 500) || req.sends > 5) {
+            if ((reqStatus > 0 && reqStatus < 500) || req.sends > this.maxRetries) {
                 // remove from internal queue
                 this._removeRequest(req);
                 Strophe.debug("request id " +
@@ -2557,7 +2557,7 @@ Strophe.Connection.prototype = {
             }
 
             if (!((reqStatus > 0 && reqStatus < 500) ||
-                  req.sends > 5)) {
+                  req.sends > this.maxRetries)) {
                 this._throttledRequestHandler();
             }
         }


### PR DESCRIPTION
 this.maxRetries variable has been introduced to keep track of number of retries.
 This variable should be used in _onRequestStateChange before the request is dropped from the internal queue after the maximum number of retries are reached.
