### PR TITLE
connection.sync for enabling/disabling synchronous connections (good for disconnect on unload)

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2388,7 +2388,8 @@ Strophe.Connection.prototype = {
                           "." + req.sends + " posting");
 
             try {
-                req.xhr.open("POST", this.service, true);
+            	var async = (this.sync) ? false : true;
+                req.xhr.open("POST", this.service, async);
             } catch (e2) {
                 Strophe.error("XHR open failed.");
                 if (!this.connected) {


### PR DESCRIPTION
Added support for a widely believed feature of Strophe that doesn't seem to actually be supported.

Setting connection.sync = true is believed to force synchronous connections according
to many blog and forum posts.  The source doesn't seem to support this at all. This little
patch makes that vaporware feature a reality.

e.g. disconnect in window.unload examples
