### PR TITLE
Refactor mechanisms to enable strophe.js to be more flexible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,18 @@ SHELL=/bin/bash
 SRC_DIR = src
 DOC_DIR = doc
 PLUGIN_DIR = plugins
+MECH_DIR = $(SRC_DIR)/mechanisms
 NDPROJ_DIR = ndproj
 
 BASE_FILES = $(SRC_DIR)/base64.js \
 	$(SRC_DIR)/sha1.js \
 	$(SRC_DIR)/md5.js \
-	$(SRC_DIR)/core.js
+	$(SRC_DIR)/core.js \
+	$(MECH_DIR)/anonymous.js \
+	$(MECH_DIR)/digest_md5.js \
+	$(MECH_DIR)/legacy_auth.js \
+	$(MECH_DIR)/plain.js \
+	$(MECH_DIR)/scram_sha1.js
 
 STROPHE = strophe.js
 STROPHE_MIN = strophe.min.js

--- a/src/mechanisms/anonymous.js
+++ b/src/mechanisms/anonymous.js
@@ -1,0 +1,68 @@
+/** Class: Strophe.Authentication.ANONYMOUS
+ * SASL ANONYMOUS Authentication implementation
+ */
+Strophe.Authentication.ANONYMOUS = function() {
+};
+
+/** Function: init
+ * Initializes the ANONYMOUS Authentication mechanism
+ */
+Strophe.Authentication.ANONYMOUS.prototype.init = function(connection) {
+	this._connection = connection;
+	this.matches = false;
+	this._successHandler = null;
+	this._failureHandler = null;
+};
+
+/** Function: authenticate
+ * Called after chosing ANONYMOUS as the mechanism.
+ */
+Strophe.Authentication.ANONYMOUS.prototype.authenticate = function() {
+	this._successHandler = this._connection._addSysHandler(
+		this.successCb.bind(this), null,
+		"success", null, null);
+	this._failureHandler = this._connection._addSysHandler(
+		this.failureCb.bind(this), null,
+		"failure", null, null);
+
+	this._connection.send($build("auth", {
+		xmlns: Strophe.NS.SASL,
+		mechanism: "ANONYMOUS"
+    }).tree());
+};
+
+/** PrivateFunction: successCb
+ * Callback after succesful authentication
+ *
+ *  Parameters:
+ *    (XMLElement) elem - The success stanza.
+ *
+ *  Returns:
+ *    false to remove the handler (by calling <Strophe.Connection._sasl_success_cb()>)
+ */
+Strophe.Authentication.ANONYMOUS.prototype.successCb = function(elem) {
+	if (this._failureHandler) {
+		this._connection.deleteHandler(this._failureHandler);
+		this._failureHandler = null;
+	}
+	return this._connection._sasl_success_cb();
+};
+
+/** PrivateFunction: failureCb
+ * Callback after failed authentication
+ *
+ *  Parameters:
+ *    (XMLElement) elem - The failure stanza.
+ *
+ *  Returns:
+ *    false to remove the handler (by calling <Strophe.Connection._sasl_failure_cb()>)
+ */
+Strophe.Authentication.ANONYMOUS.prototype.failureCb = function(elem) {
+	if (this._successHandler) {
+        this._connection.deleteHandler(this._successHandler);
+        this._successHandler = null;
+    }
+	return this._connection._sasl_failure_cb();
+};
+
+Strophe.addMechanismPlugin('ANONYMOUS', Strophe.Authentication.ANONYMOUS.prototype);

--- a/src/mechanisms/anonymous.js
+++ b/src/mechanisms/anonymous.js
@@ -9,7 +9,6 @@ Strophe.Authentication.ANONYMOUS = function() {
  */
 Strophe.Authentication.ANONYMOUS.prototype.init = function(connection) {
 	this._connection = connection;
-	this.matches = false;
 	this._successHandler = null;
 	this._failureHandler = null;
 };

--- a/src/mechanisms/digest_md5.js
+++ b/src/mechanisms/digest_md5.js
@@ -9,7 +9,6 @@ Strophe.Authentication.DIGEST_MD5 = function() {
  */
 Strophe.Authentication.DIGEST_MD5.prototype.init = function(connection) {
 	this._connection = connection;
-	this.matches = false;
 	this._data = {};
 	this._successHandler = null;
 	this._challengeHandler = null;

--- a/src/mechanisms/digest_md5.js
+++ b/src/mechanisms/digest_md5.js
@@ -1,0 +1,192 @@
+/** Class: Strophe.Authentication.DIGEST_MD5
+ * SASL DIGEST-MD5 Authentication implementation
+ */
+Strophe.Authentication.DIGEST_MD5 = function() {
+};
+
+/** Function: init
+ * Initializes the DIGEST-MD5 Authentication mechanism
+ */
+Strophe.Authentication.DIGEST_MD5.prototype.init = function(connection) {
+	this._connection = connection;
+	this.matches = false;
+	this._data = {};
+	this._successHandler = null;
+	this._challengeHandler = null;
+	this._failureHandler = null;
+};
+
+/** Function: authenticate
+ * Called after chosing DIGEST-MD5 as the mechanism.
+ */
+Strophe.Authentication.DIGEST_MD5.prototype.authenticate = function() {
+    this._challengeHandler = this._connection._addSysHandler(
+        this.challengeCb.bind(this), null,
+        "challenge", null, null);
+    this._failureHandler = this._connection._addSysHandler(
+        this.failureCb.bind(this), null,
+        "failure", null, null);
+
+    this._connection.send($build("auth", {
+        xmlns: Strophe.NS.SASL,
+        mechanism: "DIGEST-MD5"
+    }).tree());
+};
+
+/** PrivateFunction: challengeCb
+ *  _Private_ handler for DIGEST-MD5 SASL authentication.
+ *
+ *  Parameters:
+ *    (XMLElement) elem - The challenge stanza.
+ *
+ *  Returns:
+ *    false to remove the handler.
+ */
+Strophe.Authentication.DIGEST_MD5.prototype.challengeCb = function(elem) {
+    var attribMatch = /([a-z]+)=("[^"]+"|[^,"]+)(?:,|$)/;
+
+    var challenge = Base64.decode(Strophe.getText(elem));
+    var cnonce = MD5.hexdigest("" + (Math.random() * 1234567890));
+    var realm = "";
+    var host = null;
+    var nonce = "";
+    var qop = "";
+    var matches;
+
+    // remove unneeded handlers
+    this._connection.deleteHandler(this._failureHandler);
+
+    while (challenge.match(attribMatch)) {
+        matches = challenge.match(attribMatch);
+        challenge = challenge.replace(matches[0], "");
+        matches[2] = matches[2].replace(/^"(.+)"$/, "$1");
+        switch (matches[1]) {
+        case "realm":
+            realm = matches[2];
+            break;
+        case "nonce":
+            nonce = matches[2];
+            break;
+        case "qop":
+            qop = matches[2];
+            break;
+        case "host":
+            host = matches[2];
+            break;
+        }
+    }
+
+    var digest_uri = "xmpp/" + this._connection.domain;
+    if (host !== null) {
+        digest_uri = digest_uri + "/" + host;
+    }
+
+    var A1 = MD5.hash(Strophe.getNodeFromJid(this._connection.jid) +
+                      ":" + realm + ":" + this._connection.pass) +
+        ":" + nonce + ":" + cnonce;
+    var A2 = 'AUTHENTICATE:' + digest_uri;
+
+    var responseText = "";
+    responseText += 'username=' +
+        this._connection._quote(Strophe.getNodeFromJid(this._connection.jid)) + ',';
+    responseText += 'realm=' + this._connection._quote(realm) + ',';
+    responseText += 'nonce=' + this._connection._quote(nonce) + ',';
+    responseText += 'cnonce=' + this._connection._quote(cnonce) + ',';
+    responseText += 'nc="00000001",';
+    responseText += 'qop="auth",';
+    responseText += 'digest-uri=' + this._connection._quote(digest_uri) + ',';
+    responseText += 'response=' + this._connection._quote(
+        MD5.hexdigest(MD5.hexdigest(A1) + ":" +
+                      nonce + ":00000001:" +
+                      cnonce + ":auth:" +
+                      MD5.hexdigest(A2))) + ',';
+    responseText += 'charset="utf-8"';
+
+    this._challengeHandler = this._connection._addSysHandler(
+        this.challengeCb2.bind(this), null,
+        "challenge", null, null);
+    this._successHandler = this._connection._addSysHandler(
+        this.successCb.bind(this), null,
+        "success", null, null);
+    this._failureHandler = this._connection._addSysHandler(
+        this.failureCb.bind(this), null,
+        "failure", null, null);
+
+    this._connection.send($build('response', {
+        xmlns: Strophe.NS.SASL
+    }).t(Base64.encode(responseText)).tree());
+
+    return false;
+};
+
+
+/** PrivateFunction: challengeCb2
+ *  _Private_ handler for second step of DIGEST-MD5 SASL authentication.
+ *
+ *  Parameters:
+ *    (XMLElement) elem - The challenge stanza.
+ *
+ *  Returns:
+ *    false to remove the handler.
+ */
+Strophe.Authentication.DIGEST_MD5.prototype.challengeCb2 = function(elem) {
+    // remove unneeded handlers
+    this._connection.deleteHandler(this._successHandler);
+    this._connection.deleteHandler(this._failureHandler);
+
+    this._successHandler = this._connection._addSysHandler(
+        this.successCb.bind(this), null,
+        "success", null, null);
+    this._failureHandler = this._connection._addSysHandler(
+        this.failureCb.bind(this), null,
+        "failure", null, null);
+
+    this._connection.send($build('response', {
+        xmlns: Strophe.NS.SASL
+    }).tree());
+    return false;
+};
+
+/** PrivateFunction: successCb
+ * Callback after succesful authentication
+ *
+ *  Parameters:
+ *    (XMLElement) elem - The success stanza.
+ *
+ *  Returns:
+ *    false to remove the handler (by calling <Strophe.Connection._sasl_success_cb()>)
+ */
+Strophe.Authentication.DIGEST_MD5.prototype.successCb = function(elem) {
+    if (this._challengeHandler) {
+        this._connection.deleteHandler(this._challengeHandler);
+        this._challengeHandler = null;
+    }
+    if (this._failureHandler) {
+        this._connection.deleteHandler(this._failureHandler);
+        this._failureHandler = null;
+    }
+    return this._connection._sasl_success_cb();
+};
+
+/** PrivateFunction: failureCb
+ * Callback after failed authentication
+ *
+ *  Parameters:
+ *    (XMLElement) elem - The failure stanza.
+ *
+ *  Returns:
+ *    false to remove the handler (by calling <Strophe.Connection._sasl_failure_cb()>)
+ */
+Strophe.Authentication.DIGEST_MD5.prototype.failureCb = function(elem) {
+    if (this._challengeHandler) {
+        this._connection.deleteHandler(this._challengeHandler);
+        this._challengeHandler = null;
+    }
+    if (this._successHandler) {
+        this._connection.deleteHandler(this._successHandler);
+        this._successHandler = null;
+    }
+    return this._connection._sasl_failure_cb();
+};
+
+Strophe.addMechanismPlugin('DIGEST-MD5', Strophe.Authentication.DIGEST_MD5.prototype);

--- a/src/mechanisms/legacy_auth.js
+++ b/src/mechanisms/legacy_auth.js
@@ -9,7 +9,6 @@ Strophe.Authentication.LEGACY_AUTH = function() {
  */
 Strophe.Authentication.LEGACY_AUTH.prototype.init = function(connection) {
 	this._connection = connection;
-	this.matches = false;
 	this._data = {};
 	this._auth1Handler = null;
 };

--- a/src/mechanisms/legacy_auth.js
+++ b/src/mechanisms/legacy_auth.js
@@ -1,0 +1,94 @@
+/** Class: Strophe.Authentication.LEGACY_AUTH
+ * Legacy authentication implementation
+ */
+Strophe.Authentication.LEGACY_AUTH = function() {
+};
+
+/** Function: init
+ * Initializes the legacy authentication mechanism
+ */
+Strophe.Authentication.LEGACY_AUTH.prototype.init = function(connection) {
+	this._connection = connection;
+	this.matches = false;
+	this._data = {};
+	this._auth1Handler = null;
+};
+
+/** Function: authenticate
+ * Called after chosing legacy authentication as the mechanism.
+ */
+Strophe.Authentication.LEGACY_AUTH.prototype.authenticate = function() {
+	this._auth1Handler = this._connection._addSysHandler(this.auth1Cb.bind(this), null, null,
+		null, "_auth_1");
+
+    this._connection.send($iq({
+        type: "get",
+        to: this._connection.domain,
+        id: "_auth_1"
+    }).c("query", {
+        xmlns: Strophe.NS.AUTH
+    }).c("username", {}).t(Strophe.getNodeFromJid(this._connection.jid)).tree());
+};
+
+/** PrivateFunction: auth1Cb
+ *  _Private_ handler for legacy authentication.
+ *
+ *  This handler is called in response to the initial <iq type='get'/>
+ *  for legacy authentication.  It builds an authentication <iq/> and
+ *  sends it, creating a handler (calling back to _auth2_cb()) to
+ *  handle the result
+ *
+ *  Parameters:
+ *    (XMLElement) elem - The stanza that triggered the callback.
+ *
+ *  Returns:
+ *    false to remove the handler.
+ */
+Strophe.Authentication.LEGACY_AUTH.prototype.auth1Cb = function(elem) {
+    // build LEGACY_AUTHtext auth iq
+    var iq = $iq({type: "set", id: "_auth_2"})
+        .c('query', {xmlns: Strophe.NS.AUTH})
+        .c('username', {}).t(Strophe.getNodeFromJid(this._connection.jid))
+        .up()
+        .c('password').t(this._connection.pass);
+
+    if (!Strophe.getResourceFromJid(this._connection.jid)) {
+        // since the user has not supplied a resource, we pick
+        // a default one here.  unlike other auth methods, the server
+        // cannot do this for us.
+        this._connection.jid = Strophe.getBareJidFromJid(this._connection.jid) + '/strophe';
+    }
+    iq.up().c('resource', {}).t(Strophe.getResourceFromJid(this._connection.jid));
+
+    this._connection._addSysHandler(this.auth2Cb.bind(this), null,
+                        null, null, "_auth_2");
+
+    this._connection.send(iq.tree());
+
+    return false;
+};
+
+/** PrivateFunction: auth2Cb
+ * _Private_ handler to finish legacy authentication.
+ *
+ * This handler is called when the result from the jabber:iq:auth
+ * <iq/> stanza is returned.
+ *
+ * Parameters:
+ *     (XMLElement) elem - The stanza that triggered the callback.
+ *
+ * Returns:
+ *     false to remove the handler.
+*/
+Strophe.Authentication.LEGACY_AUTH.prototype.auth2Cb = function(elem) {
+    if (elem.getAttribute("type") == "result") {
+        this._connection.authenticated = true;
+        this._connection._changeConnectStatus(Strophe.Status.CONNECTED, null);
+    } else if (elem.getAttribute("type") == "error") {
+        this._connection._changeConnectStatus(Strophe.Status.AUTHFAIL, null);
+        this._connection.disconnect();
+    }
+    return false;
+}
+
+Strophe.addMechanismPlugin('LEGACY_AUTH', Strophe.Authentication.LEGACY_AUTH.prototype);

--- a/src/mechanisms/plain.js
+++ b/src/mechanisms/plain.js
@@ -1,0 +1,78 @@
+/** Class: Strophe.Authentication.PLAIN
+ * SASL PLAIN Authentication implementation
+ */
+Strophe.Authentication.PLAIN = function() {
+};
+
+/** Function: init
+ * Initializes the PLAIN Authentication mechanism
+ */
+Strophe.Authentication.PLAIN.prototype.init = function(connection) {
+	this._connection = connection;
+	this.matches = false;
+	this._data = {};
+	this._successHandler = null;
+	this._failureHandler = null;
+};
+
+/** Function: authenticate
+ * Called after chosing PLAIN as the mechanism.
+ */
+Strophe.Authentication.PLAIN.prototype.authenticate = function() {
+	// Build the plain auth string (barejid null
+    // username null password) and base 64 encoded.
+    auth_str = Strophe.getBareJidFromJid(this._connection.jid);
+    auth_str = auth_str + "\u0000";
+    auth_str = auth_str + Strophe.getNodeFromJid(this._connection.jid);
+    auth_str = auth_str + "\u0000";
+    auth_str = auth_str + this._connection.pass;
+
+    this._successHandler = this._connection._addSysHandler(
+        this.successCb.bind(this), null,
+        "success", null, null);
+    this._failureHandler = this._connection._addSysHandler(
+        this.failureCb.bind(this), null,
+        "failure", null, null);
+
+    hashed_auth_str = Base64.encode(auth_str);
+    this._connection.send($build("auth", {
+        xmlns: Strophe.NS.SASL,
+        mechanism: "PLAIN"
+    }).t(hashed_auth_str).tree());
+};
+
+/** PrivateFunction: successCb
+ * Callback after succesful authentication
+ *
+ *  Parameters:
+ *    (XMLElement) elem - The success stanza.
+ *
+ *  Returns:
+ *    false to remove the handler (by calling <Strophe.Connection._sasl_success_cb()>)
+ */
+Strophe.Authentication.PLAIN.prototype.successCb = function(elem) {
+    if (this._failureHandler) {
+        this._connection.deleteHandler(this._failureHandler);
+        this._failureHandler = null;
+    }
+    return this._connection._sasl_success_cb();
+};
+
+/** PrivateFunction: failureCb
+ * Callback after failed authentication
+ *
+ *  Parameters:
+ *    (XMLElement) elem - The failure stanza.
+ *
+ *  Returns:
+ *    false to remove the handler (by calling <Strophe.Connection._sasl_failure_cb()>)
+ */
+Strophe.Authentication.PLAIN.prototype.failureCb = function(elem) {
+    if (this._successHandler) {
+        this._connection.deleteHandler(this._successHandler);
+        this._successHandler = null;
+    }
+    return this._connection._sasl_failure_cb();
+};
+
+Strophe.addMechanismPlugin('PLAIN', Strophe.Authentication.PLAIN.prototype);

--- a/src/mechanisms/plain.js
+++ b/src/mechanisms/plain.js
@@ -9,7 +9,6 @@ Strophe.Authentication.PLAIN = function() {
  */
 Strophe.Authentication.PLAIN.prototype.init = function(connection) {
 	this._connection = connection;
-	this.matches = false;
 	this._data = {};
 	this._successHandler = null;
 	this._failureHandler = null;

--- a/src/mechanisms/scram_sha1.js
+++ b/src/mechanisms/scram_sha1.js
@@ -9,7 +9,6 @@ Strophe.Authentication.SCRAM_SHA1 = function() {
  */
 Strophe.Authentication.SCRAM_SHA1.prototype.init = function(connection) {
 	this._connection = connection;
-	this.matches = false;
 	this._data = {};
 	this._successHandler = null;
 	this._challengeHandler = null;

--- a/src/mechanisms/scram_sha1.js
+++ b/src/mechanisms/scram_sha1.js
@@ -1,0 +1,185 @@
+/** Class: Strophe.Authentication.SCRAM_SHA1
+ * SASL SCRAM-SHA-1 Authentication implementation
+ */
+Strophe.Authentication.SCRAM_SHA1 = function() {
+};
+
+/** Function: init
+ * Initializes the SCRAM-SHA-1 Authentication mechanism
+ */
+Strophe.Authentication.SCRAM_SHA1.prototype.init = function(connection) {
+	this._connection = connection;
+	this.matches = false;
+	this._data = {};
+	this._successHandler = null;
+	this._challengeHandler = null;
+	this._failureHandler = null;
+};
+
+/** Function: authenticate
+ * Called after chosing SCRAM-SHA-1 as the mechanism.
+ */
+Strophe.Authentication.SCRAM_SHA1.prototype.authenticate = function() {
+	this._challengeHandler = this._connection._addSysHandler(
+		this.challengeCb.bind(this), null,
+		"challenge", null, null);
+	this._failureHandler = this._connection._addSysHandler(
+		this.failureCb.bind(this), null,
+		"failure", null, null);
+
+    var cnonce = MD5.hexdigest(Math.random() * 1234567890);
+
+    var auth_str = "n=" + Strophe.getNodeFromJid(this._connection.jid);
+    auth_str += ",r=";
+    auth_str += cnonce;
+
+    this._data["cnonce"] = cnonce;
+    this._data["client-first-message-bare"] = auth_str;
+
+    auth_str = "n,," + auth_str;
+
+    this._connection.send($build("auth", {
+        xmlns: Strophe.NS.SASL,
+        mechanism: "SCRAM-SHA-1"
+    }).t(Base64.encode(auth_str)).tree());
+};
+
+/** PrivateFunction: challengeCb
+ *  _Private_ handler for SCRAM-SHA-1 SASL authentication.
+ *
+ *  Parameters:
+ *    (XMLElement) elem - The challenge stanza.
+ *
+ *  Returns:
+ *    false to remove the handler.
+ */
+Strophe.Authentication.SCRAM_SHA1.prototype.challengeCb = function(elem) {
+    var nonce, salt, iter, Hi, U, U_old, i, k;
+    var clientKey, serverKey, clientSignature;
+    var responseText = "c=biws,";
+    var challenge = Base64.decode(Strophe.getText(elem));
+    var authMessage = this._data["client-first-message-bare"] + "," +
+        challenge + ",";
+    var cnonce = this._data["cnonce"]
+    var attribMatch = /([a-z]+)=([^,]+)(,|$)/;
+
+    // remove unneeded handlers
+    this._connection.deleteHandler(this._failureHandler);
+
+    while (challenge.match(attribMatch)) {
+        matches = challenge.match(attribMatch);
+        challenge = challenge.replace(matches[0], "");
+        switch (matches[1]) {
+        case "r":
+            nonce = matches[2];
+            break;
+        case "s":
+            salt = matches[2];
+            break;
+        case "i":
+            iter = matches[2];
+            break;
+        }
+    }
+
+    if (!(nonce.substr(0, cnonce.length) === cnonce)) {
+        this._data = {};
+        return this.failureCb(null);
+    }
+
+    responseText += "r=" + nonce;
+    authMessage += responseText;
+
+    salt = Base64.decode(salt);
+    salt += "\0\0\0\1";
+
+    Hi = U_old = core_hmac_sha1(this._connection.pass, salt);
+    for (i = 1; i < iter; i++) {
+        U = core_hmac_sha1(this._connection.pass, binb2str(U_old));
+        for (k = 0; k < 5; k++) {
+            Hi[k] ^= U[k];
+        }
+        U_old = U;
+    }
+    Hi = binb2str(Hi);
+
+    clientKey = core_hmac_sha1(Hi, "Client Key");
+    serverKey = str_hmac_sha1(Hi, "Server Key");
+    clientSignature = core_hmac_sha1(str_sha1(binb2str(clientKey)), authMessage);
+    this._data["server-signature"] = b64_hmac_sha1(serverKey, authMessage);
+
+    for (k = 0; k < 5; k++) {
+        clientKey[k] ^= clientSignature[k];
+    }
+
+    responseText += ",p=" + Base64.encode(binb2str(clientKey));
+
+    this._successHandler = this._connection._addSysHandler(
+        this.successCb.bind(this), null,
+        "success", null, null);
+    this._failureHandler = this._connection._addSysHandler(
+        this.failureCb.bind(this), null,
+        "failure", null, null);
+
+    this._connection.send($build('response', {
+        xmlns: Strophe.NS.SASL
+    }).t(Base64.encode(responseText)).tree());
+
+    return false;
+};
+
+/** PrivateFunction: successCb
+ * Callback after succesful authentication
+ *
+ *  Parameters:
+ *    (XMLElement) elem - The success stanza.
+ *
+ *  Returns:
+ *    false to remove the handler (by calling <Strophe.Connection._sasl_success_cb()>)
+ */
+Strophe.Authentication.SCRAM_SHA1.prototype.successCb = function(elem) {
+    var serverSignature;
+    var success = Base64.decode(Strophe.getText(elem));
+    var attribMatch = /([a-z]+)=([^,]+)(,|$)/;
+    matches = success.match(attribMatch);
+    if (matches[1] == "v") {
+        serverSignature = matches[2];
+    }
+    if (serverSignature != this._data["server-signature"]) {
+        // remove old handlers
+        this._connection.deleteHandler(this._failureHandler);
+        this._failureHandler = null;
+        if (this._challengeHandler) {
+            this._connection.deleteHandler(this._challengeHandler);
+            this._challengeHandler = null;
+        }
+
+        this._data = {};
+        return this.failureCb(null);
+    }
+
+    return this._connection._sasl_success_cb();
+};
+
+/** PrivateFunction: failureCb
+ * Callback after failed authentication
+ *
+ *  Parameters:
+ *    (XMLElement) elem - The failure stanza.
+ *
+ *  Returns:
+ *    false to remove the handler (by calling <Strophe.Connection._sasl_failure_cb()>)
+ */
+Strophe.Authentication.SCRAM_SHA1.prototype.failureCb = function(elem) {
+    if (this._successHandler) {
+        this._connection.deleteHandler(this._successHandler);
+        this._successHandler = null;
+    }
+    if (this._challengeHandler) {
+        this._connection.deleteHandler(this._challengeHandler);
+        this._challengeHandler = null;
+    }
+    return this._connection._sasl_failure_cb();
+};
+
+Strophe.addMechanismPlugin('SCRAM-SHA-1', Strophe.Authentication.SCRAM_SHA1.prototype);


### PR DESCRIPTION
I refactored the whole authentication process a bit in order to enable users of strophe.js to easily develop their own auth mechanisms if needed without patching the source code.

Also this enables developers to switch mechanisms on/off on a case-by-case basis, if needed.

The order of which mechanism gets applied first when it's available for the standard SASL mechanisms hasn't been changed. 

Please take a look, comment and if you think this is cool, merge it :)
Btw. One thing to note: I couldn't test Legacy Auth because I didn't find any setting in ejabberd for that. Would be nice if somebody could test it (although I think it should work ;))
