### PR TITLE
Added namespace for receipts plugin (XEP 184) to the core file

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -196,7 +196,8 @@ Strophe = {
         VERSION: "jabber:iq:version",
         STANZAS: "urn:ietf:params:xml:ns:xmpp-stanzas",
         XHTML_IM: "http://jabber.org/protocol/xhtml-im",
-        XHTML: "http://www.w3.org/1999/xhtml"
+        XHTML: "http://www.w3.org/1999/xhtml",
+        RECEIPTS: "urn:xmpp:receipts"
     },
 
 


### PR DESCRIPTION
Added namespace for receipts plugin (XEP 184) to the core file, so if you would use the plugin it would fine the correct namespace
