### PR TITLE
Chrome and safari CORS fix

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2405,8 +2405,11 @@ Strophe.Connection.prototype = {
                 req.date = new Date();
                 /* This is a chrome CORS fix, 
                  * Chrome changes the request method from POST to 
-                 * OPTIONS thus not carriying the initial xml stanza. 
-                 * Set content type of the request to avoid this problem 
+                 * OPTIONS thus not carriying the initial xml stanza.
+                 * this keeps the http request pending for random time 
+                 * period before restarting it. 
+                 * Setting content type of the request to text/plain avoids
+                 * this problem 
                  * */
                 req.xhr.setRequestHeader('Content-Type', 'text/plain');
                 req.xhr.send(req.data);

--- a/src/core.js
+++ b/src/core.js
@@ -2403,6 +2403,12 @@ Strophe.Connection.prototype = {
             // or on a gradually expanding retry window for reconnects
             var sendFunc = function () {
                 req.date = new Date();
+                /* This is a chrome CORS fix, 
+                 * Chrome changes the request method from POST to 
+                 * OPTIONS thus not carriying the initial xml stanza. 
+                 * Set content type of the request to avoid this problem 
+                 * */
+                req.xhr.setRequestHeader('Content-Type', 'text/plain');
                 req.xhr.send(req.data);
             };
 


### PR DESCRIPTION
This is a chrome CORS fix, 
Chrome changes the request method from POST to 
OPTIONS thus not carriying the initial xml stanza.
this keeps the http request pending for random time 
period before restarting it. 
Setting content type of the request to text/plain avoids this problem 
