### PR TITLE
Exclude TypeError output like: "Uncaught TypeError: jit.split is not …

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -827,7 +827,7 @@ Strophe = {
      */
     getBareJidFromJid: function (jid)
     {
-        return jid ? jid.split("/")[0] : null;
+        return jid ? jid.toString().split("/")[0] : null;
     },
 
     /** Function: log


### PR DESCRIPTION
### Force convert jit variable to string: to exclude TypeError like:

```
"Uncaught TypeError: jit.split is not a function"
```

jid.split("/")[0] -> jid.toString().split("/")[0]
